### PR TITLE
Patch to add `box_corners` argument to `fc_draw()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flowchart
 Type: Package
 Title: Tidy Flowchart Generator
-Version: 0.5.1.9000
+Version: 0.5.2
 Authors@R: c(
     person("Pau", "Satorra", , "psatorra@igtp.cat", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-8144-4089")),
@@ -10,7 +10,9 @@ Authors@R: c(
     person("Natàlia", "Pallarès", role = "aut",
            comment = c(ORCID = "0000-0002-1462-379X")),
     person("Cristian", "Tebé", role = "aut",
-           comment = c(ORCID = "0000-0003-2320-1385"))
+           comment = c(ORCID = "0000-0003-2320-1385")),
+    person("Kenneth", "Taylor", role = "ctb",
+           comment = c(ORCID = "0000-0002-3205-9280")))
   )
 Maintainer: Pau Satorra <psatorra@igtp.cat>
 Description: Creates participant flow diagrams directly from a dataframe. Representing the flow of participants through each stage of a study, especially in clinical trials, is essential to assess the generalisability and validity of the results. This package provides a set of functions that can be combined with a pipe operator to create all kinds of flowcharts from a data frame in an easy way.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flowchart
 Type: Package
 Title: Tidy Flowchart Generator
-Version: 0.5.1
+Version: 0.5.1.9000
 Authors@R: c(
     person("Pau", "Satorra", , "psatorra@igtp.cat", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-8144-4089")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flowchart
 Type: Package
 Title: Tidy Flowchart Generator
-Version: 0.5.2
+Version: 0.5.1.90000
 Authors@R: c(
     person("Pau", "Satorra", , "psatorra@igtp.cat", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-8144-4089")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Authors@R: c(
     person("Cristian", "Tebé", role = "aut",
            comment = c(ORCID = "0000-0003-2320-1385")),
     person("Kenneth", "Taylor", role = "ctb",
-           comment = c(ORCID = "0000-0002-3205-9280")))
+           comment = c(ORCID = "0000-0002-3205-9280"))
   )
 Maintainer: Pau Satorra <psatorra@igtp.cat>
 Description: Creates participant flow diagrams directly from a dataframe. Representing the flow of participants through each stage of a study, especially in clinical trials, is essential to assess the generalisability and validity of the results. This package provides a set of functions that can be combined with a pipe operator to create all kinds of flowcharts from a data frame in an easy way.

--- a/NEWS.md
+++ b/NEWS.md
@@ -72,6 +72,6 @@
 
 * Changed license to GPL (>= 3) license
 
-# flowchart (development version)
+# flowchart 0.5.2
 
 * Added `box_corners` argument to `fc_draw()` to allow drawing boxes with or without rounded corners; default set to `"rounded"` to avoid breaking changes (#2; @kenkomodo)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,3 @@
-# flowchart (development version)
-
 # flowchart 0.1.0
 
 * Initial CRAN submission.
@@ -74,3 +72,6 @@
 
 * Changed license to GPL (>= 3) license
 
+# flowchart (development version)
+
+* Added `box_corners` argument to `fc_draw()` to allow drawing boxes with or without rounded corners; default set to `"rounded"` to avoid breaking changes (#2; @kenkomodo)

--- a/NEWS.md
+++ b/NEWS.md
@@ -72,6 +72,6 @@
 
 * Changed license to GPL (>= 3) license
 
-# flowchart 0.5.2
+# flowchart (development version)
 
-* Added `box_corners` argument to `fc_draw()` to allow drawing boxes with or without rounded corners; default set to `"rounded"` to avoid breaking changes (#2; @kenkomodo)
+* Added `box_corners` argument to `fc_draw()` to allow drawing boxes with or without round corners; default set to `"round"` to avoid breaking changes (#2; @kenkomodo)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# flowchart (development version)
+
 # flowchart 0.1.0
 
 * Initial CRAN submission.

--- a/R/fc_draw.R
+++ b/R/fc_draw.R
@@ -2,7 +2,7 @@
 #' @description This function allows to draw the flowchart from a fc object.
 #'
 #' @param object fc object that we want to draw.
-#' @param box_corners Indicator of whether to draw boxes with rounded (`"rounded"`) vs non-rounded (`"sharp"`) corners. Default is `"rounded"`.
+#' @param box_corners Indicator of whether to draw boxes with round (`"round"`) vs non-round (`"sharp"`) corners. Default is `"round"`.
 #' @param arrow_angle The angle of the arrow head in degrees, as in `arrow`.
 #' @param arrow_length A unit specifying the length of the arrow head (from tip to base), as in `arrow`.
 #' @param arrow_ends One of "last", "first", or "both", indicating which ends of the line to draw arrow heads, as in `arrow`.
@@ -29,16 +29,16 @@
 #' @export
 #' @importFrom rlang .data
 
-fc_draw <- function(object, box_corners = "rounded", arrow_angle = 30, arrow_length = grid::unit(0.1, "inches"), arrow_ends = "last", arrow_type = "closed", title = NULL, title_x = 0.5, title_y = 0.9, title_color = "black", title_fs = 15, title_fface = 2, title_ffamily = NULL) {
+fc_draw <- function(object, box_corners = "round", arrow_angle = 30, arrow_length = grid::unit(0.1, "inches"), arrow_ends = "last", arrow_type = "closed", title = NULL, title_x = 0.5, title_y = 0.9, title_color = "black", title_fs = 15, title_fface = 2, title_ffamily = NULL) {
 
   is_class(object, "fc")
 
   # Check for valid corners argument
-  if (!box_corners %in% c("rounded", "sharp")) {
-    stop("Invalid box_corners argument: must be 'rounded' or 'sharp'")
+  if (!box_corners %in% c("round", "sharp")) {
+    stop("Invalid box_corners argument: must be 'round' or 'sharp'")
   }
 
-  if (box_corners == "rounded") {
+  if (box_corners == "round") {
     rect_type <- grid::roundrectGrob
   } else {
     rect_type <- grid::rectGrob

--- a/R/fc_draw.R
+++ b/R/fc_draw.R
@@ -2,6 +2,7 @@
 #' @description This function allows to draw the flowchart from a fc object.
 #'
 #' @param object fc object that we want to draw.
+#' @param box_corners Indicator of whether to draw boxes with rounded (`"rounded"`) vs non-rounded (`"sharp"`) corners. Default is `"rounded"`.
 #' @param arrow_angle The angle of the arrow head in degrees, as in `arrow`.
 #' @param arrow_length A unit specifying the length of the arrow head (from tip to base), as in `arrow`.
 #' @param arrow_ends One of "last", "first", or "both", indicating which ends of the line to draw arrow heads, as in `arrow`.
@@ -28,9 +29,20 @@
 #' @export
 #' @importFrom rlang .data
 
-fc_draw <- function(object, arrow_angle = 30, arrow_length = grid::unit(0.1, "inches"), arrow_ends = "last", arrow_type = "closed", title = NULL, title_x = 0.5, title_y = 0.9, title_color = "black", title_fs = 15, title_fface = 2, title_ffamily = NULL) {
+fc_draw <- function(object, box_corners = "rounded", arrow_angle = 30, arrow_length = grid::unit(0.1, "inches"), arrow_ends = "last", arrow_type = "closed", title = NULL, title_x = 0.5, title_y = 0.9, title_color = "black", title_fs = 15, title_fface = 2, title_ffamily = NULL) {
 
   is_class(object, "fc")
+
+  # Check for valid corners argument
+  if (!box_corners %in% c("rounded", "sharp")) {
+    stop("Invalid box_corners argument: must be 'rounded' or 'sharp'")
+  }
+
+  if (box_corners == "rounded") {
+    rect_type <- grid::roundrectGrob
+  } else {
+    rect_type <- grid::rectGrob
+  }
 
   #Initialize grid
   grid::grid.newpage()
@@ -51,7 +63,7 @@ fc_draw <- function(object, arrow_angle = 30, arrow_length = grid::unit(0.1, "in
                             bg = purrr::pmap(list(.data$x, .data$y, .data$text, .data$type, .data$group, .data$just, .data$text_color, .data$text_fs, .data$text_fface, .data$text_ffamily, .data$text_padding, .data$bg_fill, .data$border_color), function(...) {
                               arg <- list(...)
                               names(arg) <- c("x", "y", "text", "type", "group", "just", "text_color", "text_fs", "text_fface", "text_ffamily", "text_padding", "bg_fill", "border_color")
-                              Gmisc::boxGrob(arg$text, x = arg$x, y = arg$y, just = arg$just, txt_gp = grid::gpar(col = arg$text_color, fontsize = arg$text_fs/arg$text_padding, fontface = arg$text_fface, fontfamily = arg$text_ffamily, cex = arg$text_padding), box_gp = grid::gpar(fill = arg$bg_fill, col = arg$border_color))
+                              Gmisc::boxGrob(arg$text, x = arg$x, y = arg$y, just = arg$just, txt_gp = grid::gpar(col = arg$text_color, fontsize = arg$text_fs/arg$text_padding, fontface = arg$text_fface, fontfamily = arg$text_ffamily, cex = arg$text_padding), box_gp = grid::gpar(fill = arg$bg_fill, col = arg$border_color), box_fn = rect_type)
                             })
                           )
   )

--- a/man/fc_draw.Rd
+++ b/man/fc_draw.Rd
@@ -6,6 +6,7 @@
 \usage{
 fc_draw(
   object,
+  box_corners = "rounded",
   arrow_angle = 30,
   arrow_length = grid::unit(0.1, "inches"),
   arrow_ends = "last",
@@ -21,6 +22,8 @@ fc_draw(
 }
 \arguments{
 \item{object}{fc object that we want to draw.}
+
+\item{box_corners}{Indicator of whether to draw boxes with rounded (`"rounded"`) vs non-rounded (`"sharp"`) corners. Default is `"rounded"`.}
 
 \item{arrow_angle}{The angle of the arrow head in degrees, as in `arrow`.}
 

--- a/man/fc_draw.Rd
+++ b/man/fc_draw.Rd
@@ -6,7 +6,7 @@
 \usage{
 fc_draw(
   object,
-  box_corners = "rounded",
+  box_corners = "round",
   arrow_angle = 30,
   arrow_length = grid::unit(0.1, "inches"),
   arrow_ends = "last",
@@ -23,7 +23,7 @@ fc_draw(
 \arguments{
 \item{object}{fc object that we want to draw.}
 
-\item{box_corners}{Indicator of whether to draw boxes with rounded (`"rounded"`) vs non-rounded (`"sharp"`) corners. Default is `"rounded"`.}
+\item{box_corners}{Indicator of whether to draw boxes with round (`"round"`) vs non-round (`"sharp"`) corners. Default is `"round"`.}
 
 \item{arrow_angle}{The angle of the arrow head in degrees, as in `arrow`.}
 

--- a/vignettes/flowchart.Rmd
+++ b/vignettes/flowchart.Rmd
@@ -158,23 +158,6 @@ safo |>
 
 We can customize the flowchart either with the arguments provided by each function in the process of creating it, or directly in the final output using the function `fc_modify`. We can also change the box style for all boxes in the flowchart using an argument in `fc_draw`.
 
-## Change box type
-
-To set whether we want rounded corners or not for all the boxes in our flowchart, we can use the `box_corners` argument with `fc_draw`.
-
-For example, adding `box_corners = "sharp"` changes the box corner style from the default (rounded):
-
-```{r fig.width = 6, fig.height = 4}
- safo_fc <- safo |> 
-  as_fc(label = "Patients assessed for eligibility") |>
-  fc_filter(!is.na(group), label = "Randomized", show_exc = TRUE) 
-
-safo_fc |> 
-  fc_draw(box_corners = "sharp")
-```
-
-
-
 ## Change function arguments
 
 Arguments common to `as_fc()`, `fc_filter()` and `fc_split()`, to customise the appearance of the boxes created at each step:
@@ -407,6 +390,10 @@ Arguments common to `as_fc()`, `fc_filter()` and `fc_split()`, to customise the 
   </tr>
  </thead>
 <tbody>
+  <tr>
+   <td style="text-align:left;"> `box_corners=` </td>
+   <td style="text-align:left;"> specify corner type for all flowchart boxes. </td>
+  </tr>
   <tr>
    <td style="text-align:left;"> `arrow_angle=` </td>
    <td style="text-align:left;"> angle of the arrow head in degrees. </td>
@@ -726,4 +713,16 @@ safo |>
   fc_filter(!is.na(group), label = "Randomized", show_exc = TRUE, offset_exc = 0.1) |> 
   fc_split(group) |> 
   fc_draw()
+```
+
+### Change Box Corner Style
+
+We can change the corner style of the flowchart boxes using the `box_corners` argument with `fc_draw`:
+
+```{r fig.width = 6, fig.height = 5}
+safo |> 
+  as_fc(label = "Patients assessed for eligibility") |>
+  fc_filter(!is.na(group), label = "Randomized", show_exc = TRUE) |> 
+  fc_split(group) |> 
+  fc_draw(box_corners = "sharp")
 ```

--- a/vignettes/flowchart.Rmd
+++ b/vignettes/flowchart.Rmd
@@ -156,7 +156,24 @@ safo |>
 
 # Customize output
 
-We can customize the flowchart either with the arguments provided by each function in the process of creating it, or directly in the final output using the function `modify_fc`. 
+We can customize the flowchart either with the arguments provided by each function in the process of creating it, or directly in the final output using the function `fc_modify`. We can also change the box style for all boxes in the flowchart using an argument in `fc_draw`.
+
+## Change box type
+
+To set whether we want rounded corners or not for all the boxes in our flowchart, we can use the `box_corners` argument with `fc_draw`.
+
+For example, adding `box_corners = "sharp"` changes the box corner style from the default (rounded):
+
+```{r fig.width = 6, fig.height = 4}
+ safo_fc <- safo |> 
+  as_fc(label = "Patients assessed for eligibility") |>
+  fc_filter(!is.na(group), label = "Randomized", show_exc = TRUE) 
+
+safo_fc |> 
+  fc_draw(box_corners = "sharp")
+```
+
+
 
 ## Change function arguments
 
@@ -440,7 +457,7 @@ Arguments common to `as_fc()`, `fc_filter()` and `fc_split()`, to customise the 
 
 ## Function to customize the flowchart
 
-The function `modify_fc` allows the user to customise the created flowchart by modifying its parameters, which are stored in `.$fc`. 
+The function `fc_modify` allows the user to customise the created flowchart by modifying its parameters, which are stored in `.$fc`. 
 
 For example, let's customize the following flowchart:
 


### PR DESCRIPTION
Summary of changes:
- Added `box_corners` argument to `fc_draw()` with options `"rounded"` or `"sharp"`
  - Default set to `"rounded"` to prevent change in behavior for current users who expect/want rounded corners from their existing scripts
- Updated `fc_draw()` documentation with new argument
- Fixed a typo in the vignette and added an example use of `box_corners` argument to vignette
- Updated `NEWS.md` with change
- Incremented version to 0.5.2

All checks passed locally with `devtools::check()`.

Resolves #2 