### PR TITLE
Updating `fc_export()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Imports:
     grDevices
 Suggests: 
     knitr,
+    ragg,
     rmarkdown
 VignetteBuilder: knitr
 Depends: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -75,3 +75,5 @@
 # flowchart (development version)
 
 * Added `box_corners` argument to `fc_draw()` to allow drawing boxes with or without round corners; default set to `"round"` to avoid breaking changes (#2; @kenkomodo)
+
+* Updated `fc_export()` to include vector formats (svg, pdf) and to use `ragg` in place of `grDevices` for relevant bitmap formats (png, jpeg, tiff) for improved performance and image quality when `ragg` is installed (#16; @kenkomodo)

--- a/R/fc_export.R
+++ b/R/fc_export.R
@@ -2,7 +2,7 @@
 #' @description This function allows you to export the drawn flowchart to the most popular graphic formats, including bitmap formats (png, jpeg, tiff, bmp) and vector formats (svg, pdf). For bitmap formats, it uses the `ragg` package devices when available for higher performance and higher quality output than standard raster devices provide by `grDevices`.
 #'
 #' @details
-#' - **Vector Formats ('svg', 'pdf'):** These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies `units` other than inches, the function will convert the dimensions to inches using standard conversion formulas for "mm" and "cm" `units`; "px" conversion to inches is calculated using the specified dimension divided by `res`.
+#' - **Vector Formats ('svg', 'pdf'):** These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies `units` other than inches ("mm" or "cm"), the function will convert the dimensions to inches using standard conversion formulas.
 #' - **Bitmap Formats ('png', 'jpeg', 'tiff', 'bmp'):** For these formats (with the exception of 'bmp'), the function uses the `ragg` package devices when available, providing higher performance and higher quality output. The default units for width and height are pixels.
 #' - **Suggested Dependencies:** For superior performance and quality bitmap outputs, it is recommended to install the `ragg` package. For exporting to 'pdf' format with enhanced features, the Cairo graphics library will be used if it is available.
 #'
@@ -11,8 +11,8 @@
 #' @param path Path of the directory to save plot to: path and filename are combined to create the fully qualified file name. Defaults to the working directory.
 #' @param format Name of the graphic device. One of 'png', 'jpeg', 'tiff', 'bmp', 'svg', or 'pdf'. If `NULL` (default), the format is guessed based on the filename extension.
 #' @param width,height Plot size in units expressed by the `units` argument. Default is 600px for bitmap formats and 6 inches for vector formats.
-#' @param units One of the following units in which the width and height arguments are expressed: "in", "cm", "mm" or "px". Defaults are "px" for bitmap formats and "in" for vector formats.
-#' @param res The nominal resolution in ppi which will be recorded in the bitmap file, if a positive integer. Also used for units other than the default, and to convert points to pixels. Default is 100.
+#' @param units One of the following units in which the width and height arguments are expressed: "in", "cm", "mm" for vector formats and "in", "cm", "mm" or "px" for bitmap formats. If left `NULL` (default), the function will automatically use "px" for bitmap formats and "in" for vector formats.
+#' @param res The nominal resolution in ppi which will be recorded in the bitmap file, if a positive integer. Also used for units other than the default, and to convert points to pixels. Default is 100 if exporting in bitmap format. This argument is unused if exporting to a vector format.
 #' @return Invisibly returns the same object that has been given to the function.
 #'
 #' @examples
@@ -47,7 +47,7 @@
 #' @export
 #' @importFrom rlang .data
 
-fc_export <- function(object, filename, path = NULL, format = NULL, width = NA, height = NA, units = "px", res = 100) {
+fc_export <- function(object, filename, path = NULL, format = NULL, width = NA, height = NA, units = NULL, res = 100) {
 
   is_class(object, "fc")
 
@@ -85,47 +85,52 @@ fc_export <- function(object, filename, path = NULL, format = NULL, width = NA, 
     filename <- file.path(path, filename)
   }
 
-  #Handle units and default dimensions
-  units_conv <- c("in", "cm", "mm", "px")
-  if (!(units %in% units_conv)) {
-    stop("Invalid units. Units must be one of 'in', 'cm', 'mm', 'px'.")
+  # Set default units based on format if units is NULL (default)
+  if (is.null(units)) {
+    if (format %in% c("svg", "pdf")) {
+      units <- "in"
+    } else {
+      units <- "px"
+    }
   }
 
-  #Set default dimensions based on format
+  # Handle units and default dimensions
   if (format %in% c("svg", "pdf")) {
-    #For vector formats, default dimensions in inches
+    # For vector formats, units cannot be 'px'
+    units_conv <- c("in", "cm", "mm")
+    if (!(units %in% units_conv)) {
+      stop("Invalid units for vector formats. Units must be one of 'in', 'cm', or 'mm'.")
+    }
+    # Set default dimensions if missing width in inches and alert user if they specified different unit type
     if (is.na(width)) {
       width <- 6
       if (units != "in") {
-        warning("For vector formats (svg, pdf), default width is in inches.")
-        units <- "in"
+        warning("If width is missing for vector formats (svg, pdf), default width is 6 inches.")
       }
     }
+    # Set default dimensions if missing height in inches and alert user if they specified different unit type
     if (is.na(height)) {
       height <- 6
       if (units != "in") {
-        warning("For vector formats (svg, pdf), default height is in inches.")
-        units <- "in"
+        warning("If height is missing for vector formats (svg, pdf), default height is 6 inches.")
       }
     }
-    #Convert units to inches if necessary
+    # Convert units to inches if necessary
     width_in <- switch(units,
                        "in" = width,
                        "cm" = width / 2.54,
-                       "mm" = width / 25.4,
-                       "px" = width / res)
+                       "mm" = width / 25.4)
     height_in <- switch(units,
                         "in" = height,
                         "cm" = height / 2.54,
-                        "mm" = height / 25.4,
-                        "px" = height / res)
-    #Open the appropriate device
+                        "mm" = height / 25.4)
+    # Open the appropriate device
     if (format == "svg") {
       grDevices::svg(
         filename = filename,
         width = width_in,
         height = height_in
-        )
+      )
     } else if (format == "pdf") {
       if (capabilities("cairo")) {
         grDevices::cairo_pdf(
@@ -143,19 +148,22 @@ fc_export <- function(object, filename, path = NULL, format = NULL, width = NA, 
       }
     }
   } else {
-    #For bitmap formats
+    # For bitmap formats, units can be 'in', 'cm', 'mm', or 'px'
+    units_conv <- c("in", "cm", "mm", "px")
+    if (!(units %in% units_conv)) {
+      stop("Invalid units for bitmap formats. Units must be one of 'in', 'cm', 'mm', or 'px'.")
+    }
+    # Set default dimensions if missing
     if (is.na(width)) {
       width <- 600
-      if(units != "px") {
-        warning("If width is missing, the default units are pixels.")
-        units <- "px"
+      if (units != "px") {
+        warning("If width is missing for bitmap formats, default width is 600 pixels.")
       }
     }
-    if(is.na(height)) {
+    if (is.na(height)) {
       height <- 600
-      if(units != "px") {
-        warning("If height is missing, the default units are pixels.")
-        units <- "px"
+      if (units != "px") {
+        warning("If height is missing for bitmap formats, default height is 600 pixels.")
       }
     }
     #Open the bitmap device, using ragg-based devices when available

--- a/R/fc_export.R
+++ b/R/fc_export.R
@@ -1,12 +1,17 @@
 #' @title fc_export
-#' @description This function allows you to export the drawn flowchart to the most popular graphic devices (png, jpeg, tiff, bmp).
+#' @description This function allows you to export the drawn flowchart to the most popular graphic formats, including bitmap formats (png, jpeg, tiff, bmp) and vector formats (svg, pdf). For bitmap formats, it uses the `ragg` package devices when available for higher performance and higher quality output than standard raster devices provide by `grDevices`.
+#'
+#' @details
+#' - **Vector Formats ('svg', 'pdf'):** These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies `units` other than inches, the function will convert the dimensions to inches using standard conversion formulas for "mm" and "cm" `units`; "px" conversion to inches is calculated using the specified dimension divided by `res`.
+#' - **Bitmap Formats ('png', 'jpeg', 'tiff', 'bmp'):** For these formats, the function uses the `ragg` package devices when available, providing higher performance and higher quality output. The default units for width and height are pixels.
+#' - **Suggested Dependencies:** For superior performance and quality bitmap outputs, it is recommended to install the `ragg` package. For exporting to 'pdf' format with enhanced features, the Cairo graphics library will be used if it is available.
 #'
 #' @param object fc object that we want to export.
 #' @param filename File name to create on disk.
 #' @param path Path of the directory to save plot to: path and filename are combined to create the fully qualified file name. Defaults to the working directory.
-#' @param format Name of the graphic device. One of 'png', 'jpeg', 'tiff' or 'bmp'. If NULL (default), the format is guessed based on the filename extension.
-#' @param width,height Plot size in units expressed by the `units` argument. Default is 600px.
-#' @param units One of the following units in which the width and height arguments are expressed: "in", "cm", "mm" or "px". Default is "px".
+#' @param format Name of the graphic device. One of 'png', 'jpeg', 'tiff', 'bmp', 'svg', or 'pdf'. If `NULL` (default), the format is guessed based on the filename extension.
+#' @param width,height Plot size in units expressed by the `units` argument. Default is 600px for bitmap formats and 6 inches for vector formats.
+#' @param units One of the following units in which the width and height arguments are expressed: "in", "cm", "mm" or "px". Defaults are "px" for bitmap formats and "in" for vector formats.
 #' @param res The nominal resolution in ppi which will be recorded in the bitmap file, if a positive integer. Also used for units other than the default, and to convert points to pixels. Default is 100.
 #' @return Invisibly returns the same object that has been given to the function.
 #'
@@ -18,13 +23,26 @@
 #'  fc_draw() |>
 #'  fc_export("flowchart.png")
 #'
-#'  #Specifying size and resolution
-#'  safo |>
-#'   as_fc(label = "Patients assessed for eligibility") |>
-#'   fc_filter(!is.na(group), label = "Randomized", show_exc = TRUE) |>
-#'   fc_draw() |>
-#'   fc_export("flowchart.png", width = 2500, height = 2000, res = 700)
+#' #Specifying size and resolution
+#' safo |>
+#'  as_fc(label = "Patients assessed for eligibility") |>
+#'  fc_filter(!is.na(group), label = "Randomized", show_exc = TRUE) |>
+#'  fc_draw() |>
+#'  fc_export("flowchart.png", width = 2500, height = 2000, res = 700)
 #'
+#' #Exporting to an SVG file
+#' safo |>
+#'  as_fc(label = "Patients assessed for eligibility") |>
+#'  fc_filter(!is.na(group), label = "Randomized", show_exc = TRUE) |>
+#'  fc_draw() |>
+#'  fc_export("flowchart.svg")
+#'
+#' #Exporting to a PDF file
+#' safo |>
+#'  as_fc(label = "Patients assessed for eligibility") |>
+#'  fc_filter(!is.na(group), label = "Randomized", show_exc = TRUE) |>
+#'  fc_draw() |>
+#'  fc_export("flowchart.pdf")
 #' }
 #' @export
 #' @importFrom rlang .data
@@ -57,33 +75,111 @@ fc_export <- function(object, filename, path = NULL, format = NULL, width = NA, 
     }
   }
 
-  #If format is not one of 'png', 'jpeg', 'tiff' or 'bmp':
-  if(! format %in% c("png", "jpeg", "tiff", "bmp")) {
-    stop("The format has to be one of png, jpeg, tiff or bmp")
+  #If format is not one of 'png', 'jpeg', 'tiff', 'bmp', 'svg', or 'pdf':
+  valid_formats <- c("png", "jpeg", "tiff", "bmp", "svg", "pdf")
+  if(! format %in% valid_formats) {
+    stop(paste("The format has to be one of the following:", paste(valid_formats, collapse = ", ")))
   }
 
   if (!is.null(path)) {
     filename <- file.path(path, filename)
   }
 
-  if (is.na(width)) {
-    width <- 600
-    if(units != "px") {
-      warning("If width is missing the default units are taken in pixels.")
-      units <- "px"
-    }
+  #Handle units and default dimensions
+  units_conv <- c("in", "cm", "mm", "px")
+  if (!(units %in% units_conv)) {
+    stop("Invalid units. Units must be one of 'in', 'cm', 'mm', 'px'.")
   }
 
-  if(is.na(height)) {
-    height <- 600
-    if(units != "px") {
-      warning("If height is missing the default units are taken in pixels.")
-      units <- "px"
+  #Set default dimensions based on format
+  if (format %in% c("svg", "pdf")) {
+    #For vector formats, default dimensions in inches
+    if (is.na(width)) {
+      width <- 6
+      if (units != "in") {
+        warning("For vector formats (svg, pdf), default width is in inches.")
+        units <- "in"
+      }
     }
+    if (is.na(height)) {
+      height <- 6
+      if (units != "in") {
+        warning("For vector formats (svg, pdf), default height is in inches.")
+        units <- "in"
+      }
+    }
+    #Convert units to inches if necessary
+    width_in <- switch(units,
+                       "in" = width,
+                       "cm" = width / 2.54,
+                       "mm" = width / 25.4,
+                       "px" = width / res)
+    height_in <- switch(units,
+                        "in" = height,
+                        "cm" = height / 2.54,
+                        "mm" = height / 25.4,
+                        "px" = height / res)
+    #Open the appropriate device
+    if (format == "svg") {
+      grDevices::svg(
+        filename = filename,
+        width = width_in,
+        height = height_in
+        )
+    } else if (format == "pdf") {
+      if (capabilities("cairo")) {
+        grDevices::cairo_pdf(
+          filename = filename,
+          width = width_in,
+          height = height_in
+        )
+      } else {
+        warning("Cairo graphics library is not available. Falling back to `grDevices::pdf()`.")
+        grDevices::pdf(
+          file = filename,
+          width = width_in,
+          height = height_in
+        )
+      }
+    }
+  } else {
+    #For bitmap formats
+    if (is.na(width)) {
+      width <- 600
+      if(units != "px") {
+        warning("If width is missing, the default units are pixels.")
+        units <- "px"
+      }
+    }
+    if(is.na(height)) {
+      height <- 600
+      if(units != "px") {
+        warning("If height is missing, the default units are pixels.")
+        units <- "px"
+      }
+    }
+    #Open the bitmap device, using ragg-based devices when available
+    #Map formats to device functions explicitly
+    if (format %in% c("png", "jpeg", "tiff")) {
+      if (rlang::is_installed("ragg")) {
+        device_fun <- switch(format,
+                             png = ragg::agg_png,
+                             jpeg = ragg::agg_jpeg,
+                             tiff = ragg::agg_tiff)
+      } else {
+        warning(" Defaulting to `grDevices` package since `ragg` is not installed.\n   Consider installing the `ragg` package for higher quality png, jpeg, and tiff images.")
+        device_fun <- switch(format,
+                             png = grDevices::png,
+                             jpeg = grDevices::jpeg,
+                             tiff = grDevices::tiff)
+      }
+    } else {
+      device_fun <- switch(format, bmp = grDevices::bmp)
+    }
+    device_fun(filename = filename, width = width, height = height, units = units, res = res)
   }
 
-  grDevices::dev.copy(device = get(format), filename = filename, width = width, height = height, units = units, res = res)
-
+  #Redraw the plot
   object |>
     fc_draw(arrow_angle = params$arrow_angle, arrow_length = params$arrow_length, arrow_ends = params$arrow_ends, arrow_type = params$arrow_type)
 

--- a/R/fc_export.R
+++ b/R/fc_export.R
@@ -3,7 +3,7 @@
 #'
 #' @details
 #' - **Vector Formats ('svg', 'pdf'):** These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies `units` other than inches, the function will convert the dimensions to inches using standard conversion formulas for "mm" and "cm" `units`; "px" conversion to inches is calculated using the specified dimension divided by `res`.
-#' - **Bitmap Formats ('png', 'jpeg', 'tiff', 'bmp'):** For these formats, the function uses the `ragg` package devices when available, providing higher performance and higher quality output. The default units for width and height are pixels.
+#' - **Bitmap Formats ('png', 'jpeg', 'tiff', 'bmp'):** For these formats (with the exception of 'bmp'), the function uses the `ragg` package devices when available, providing higher performance and higher quality output. The default units for width and height are pixels.
 #' - **Suggested Dependencies:** For superior performance and quality bitmap outputs, it is recommended to install the `ragg` package. For exporting to 'pdf' format with enhanced features, the Cairo graphics library will be used if it is available.
 #'
 #' @param object fc object that we want to export.

--- a/man/fc_export.Rd
+++ b/man/fc_export.Rd
@@ -38,7 +38,7 @@ This function allows you to export the drawn flowchart to the most popular graph
 }
 \details{
 - **Vector Formats ('svg', 'pdf'):** These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies `units` other than inches, the function will convert the dimensions to inches using standard conversion formulas for "mm" and "cm" `units`; "px" conversion to inches is calculated using the specified dimension divided by `res`.
-- **Bitmap Formats ('png', 'jpeg', 'tiff', 'bmp'):** For these formats, the function uses the `ragg` package devices when available, providing higher performance and higher quality output. The default units for width and height are pixels.
+- **Bitmap Formats ('png', 'jpeg', 'tiff', 'bmp'):** For these formats (with the exception of 'bmp'), the function uses the `ragg` package devices when available, providing higher performance and higher quality output. The default units for width and height are pixels.
 - **Suggested Dependencies:** For superior performance and quality bitmap outputs, it is recommended to install the `ragg` package. For exporting to 'pdf' format with enhanced features, the Cairo graphics library will be used if it is available.
 }
 \examples{

--- a/man/fc_export.Rd
+++ b/man/fc_export.Rd
@@ -11,7 +11,7 @@ fc_export(
   format = NULL,
   width = NA,
   height = NA,
-  units = "px",
+  units = NULL,
   res = 100
 )
 }
@@ -26,9 +26,9 @@ fc_export(
 
 \item{width, height}{Plot size in units expressed by the `units` argument. Default is 600px for bitmap formats and 6 inches for vector formats.}
 
-\item{units}{One of the following units in which the width and height arguments are expressed: "in", "cm", "mm" or "px". Defaults are "px" for bitmap formats and "in" for vector formats.}
+\item{units}{One of the following units in which the width and height arguments are expressed: "in", "cm", "mm" for vector formats and "in", "cm", "mm" or "px" for bitmap formats. If left `NULL` (default), the function will automatically use "px" for bitmap formats and "in" for vector formats.}
 
-\item{res}{The nominal resolution in ppi which will be recorded in the bitmap file, if a positive integer. Also used for units other than the default, and to convert points to pixels. Default is 100.}
+\item{res}{The nominal resolution in ppi which will be recorded in the bitmap file, if a positive integer. Also used for units other than the default, and to convert points to pixels. Default is 100 if exporting in bitmap format. This argument is unused if exporting to a vector format.}
 }
 \value{
 Invisibly returns the same object that has been given to the function.
@@ -37,7 +37,7 @@ Invisibly returns the same object that has been given to the function.
 This function allows you to export the drawn flowchart to the most popular graphic formats, including bitmap formats (png, jpeg, tiff, bmp) and vector formats (svg, pdf). For bitmap formats, it uses the `ragg` package devices when available for higher performance and higher quality output than standard raster devices provide by `grDevices`.
 }
 \details{
-- **Vector Formats ('svg', 'pdf'):** These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies `units` other than inches, the function will convert the dimensions to inches using standard conversion formulas for "mm" and "cm" `units`; "px" conversion to inches is calculated using the specified dimension divided by `res`.
+- **Vector Formats ('svg', 'pdf'):** These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies `units` other than inches ("mm" or "cm"), the function will convert the dimensions to inches using standard conversion formulas.
 - **Bitmap Formats ('png', 'jpeg', 'tiff', 'bmp'):** For these formats (with the exception of 'bmp'), the function uses the `ragg` package devices when available, providing higher performance and higher quality output. The default units for width and height are pixels.
 - **Suggested Dependencies:** For superior performance and quality bitmap outputs, it is recommended to install the `ragg` package. For exporting to 'pdf' format with enhanced features, the Cairo graphics library will be used if it is available.
 }

--- a/man/fc_export.Rd
+++ b/man/fc_export.Rd
@@ -22,11 +22,11 @@ fc_export(
 
 \item{path}{Path of the directory to save plot to: path and filename are combined to create the fully qualified file name. Defaults to the working directory.}
 
-\item{format}{Name of the graphic device. One of 'png', 'jpeg', 'tiff' or 'bmp'. If NULL (default), the format is guessed based on the filename extension.}
+\item{format}{Name of the graphic device. One of 'png', 'jpeg', 'tiff', 'bmp', 'svg', or 'pdf'. If `NULL` (default), the format is guessed based on the filename extension.}
 
-\item{width, height}{Plot size in units expressed by the `units` argument. Default is 600px.}
+\item{width, height}{Plot size in units expressed by the `units` argument. Default is 600px for bitmap formats and 6 inches for vector formats.}
 
-\item{units}{One of the following units in which the width and height arguments are expressed: "in", "cm", "mm" or "px". Default is "px".}
+\item{units}{One of the following units in which the width and height arguments are expressed: "in", "cm", "mm" or "px". Defaults are "px" for bitmap formats and "in" for vector formats.}
 
 \item{res}{The nominal resolution in ppi which will be recorded in the bitmap file, if a positive integer. Also used for units other than the default, and to convert points to pixels. Default is 100.}
 }
@@ -34,7 +34,12 @@ fc_export(
 Invisibly returns the same object that has been given to the function.
 }
 \description{
-This function allows you to export the drawn flowchart to the most popular graphic devices (png, jpeg, tiff, bmp).
+This function allows you to export the drawn flowchart to the most popular graphic formats, including bitmap formats (png, jpeg, tiff, bmp) and vector formats (svg, pdf). For bitmap formats, it uses the `ragg` package devices when available for higher performance and higher quality output than standard raster devices provide by `grDevices`.
+}
+\details{
+- **Vector Formats ('svg', 'pdf'):** These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies `units` other than inches, the function will convert the dimensions to inches using standard conversion formulas for "mm" and "cm" `units`; "px" conversion to inches is calculated using the specified dimension divided by `res`.
+- **Bitmap Formats ('png', 'jpeg', 'tiff', 'bmp'):** For these formats, the function uses the `ragg` package devices when available, providing higher performance and higher quality output. The default units for width and height are pixels.
+- **Suggested Dependencies:** For superior performance and quality bitmap outputs, it is recommended to install the `ragg` package. For exporting to 'pdf' format with enhanced features, the Cairo graphics library will be used if it is available.
 }
 \examples{
 \dontrun{
@@ -44,12 +49,25 @@ safo |>
  fc_draw() |>
  fc_export("flowchart.png")
 
- #Specifying size and resolution
- safo |>
-  as_fc(label = "Patients assessed for eligibility") |>
-  fc_filter(!is.na(group), label = "Randomized", show_exc = TRUE) |>
-  fc_draw() |>
-  fc_export("flowchart.png", width = 2500, height = 2000, res = 700)
+#Specifying size and resolution
+safo |>
+ as_fc(label = "Patients assessed for eligibility") |>
+ fc_filter(!is.na(group), label = "Randomized", show_exc = TRUE) |>
+ fc_draw() |>
+ fc_export("flowchart.png", width = 2500, height = 2000, res = 700)
 
+#Exporting to an SVG file
+safo |>
+ as_fc(label = "Patients assessed for eligibility") |>
+ fc_filter(!is.na(group), label = "Randomized", show_exc = TRUE) |>
+ fc_draw() |>
+ fc_export("flowchart.svg")
+
+#Exporting to a PDF file
+safo |>
+ as_fc(label = "Patients assessed for eligibility") |>
+ fc_filter(!is.na(group), label = "Randomized", show_exc = TRUE) |>
+ fc_draw() |>
+ fc_export("flowchart.pdf")
 }
 }

--- a/vignettes/flowchart.Rmd
+++ b/vignettes/flowchart.Rmd
@@ -526,7 +526,7 @@ list(fc1, fc2) |>
 
 # Export
 
-Once the flowchart has been drawn we can export it to the most popular image formats (png, jpeg, tiff, bmp) using `fc_export()`:
+Once the flowchart has been drawn we can export it to the most popular image formats, including both bitmap (png, jpeg, tiff, bmp) and vector (svg, pdf) formats, using `fc_export()`:
 
 ```{r eval = FALSE}
 safo |> 


### PR DESCRIPTION
Closes #16 

Updates:
- Added `ragg` as conditional dependency
  - `ragg` used for png, jpeg, and tiff formats when user has it installed; if not installed, function falls back on `grDevices` and outputs a message to the user to alert them that `ragg` may improve their image quality. _Note_: `ragg` does not have an analogous function to generate bmp files, so bmp will always use `grDevices`
- Added options for vector formats (svg, pdf), ensuring that if other units are supplied when using these formats they are converted to inches (underlying functions only accept units in inches)
- Updated function documentation, vignette, and NEWS.md accordingly