### PR TITLE
Updated `fc_draw()` and `fc_export()` to allow different canvas background color

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -107,3 +107,7 @@
 * Updated package functions to throw warnings using `cli`; added dependency on `cli` (@kenkomodo)
 
 * Added test suite for package functions (@kenkomodo)
+
+* Updated `fc_draw()` with `canvas_bg` argument which allows the user to specify the flowchart canvas background color or to set it to `"transparent"` (#30; @kenkomodo)
+
+* Updated `fc_export()` to accept the new `canvas_bg` argument from `fc_draw()` and apply it accordingly to the exported flowchart image (#30; @kenkomodo)

--- a/R/fc_draw.R
+++ b/R/fc_draw.R
@@ -15,6 +15,7 @@
 #' @param title_fs Font size of the title. It is 15 by default. See the `fontsize` parameter for \code{\link{gpar}}.
 #' @param title_fface Font face of the title. It is 2 by default. See the `fontface` parameter for \code{\link{gpar}}.
 #' @param title_ffamily Changes the font family of the title. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}.
+#' @param canvas_bg Background color for the entire canvas (the area behind the flowchart boxes). Default is `"white"`. Set to `"transparent"` or `NULL` for a transparent background (compatible with all `fc_export()` formats except `"jpeg"` and `"bmp"`).
 
 #' @return Invisibly returns the same object that has been given to the function, with the given arguments to draw the flowchart stored in the attributes.
 #'
@@ -29,7 +30,7 @@
 #'
 #' @export
 
-fc_draw <- function(object, big.mark = "", box_corners = "round", arrow_angle = 30, arrow_length = grid::unit(0.1, "inches"), arrow_ends = "last", arrow_type = "closed", title = NULL, title_x = 0.5, title_y = 0.9, title_color = "black", title_fs = 15, title_fface = 2, title_ffamily = NULL) {
+fc_draw <- function(object, big.mark = "", box_corners = "round", arrow_angle = 30, arrow_length = grid::unit(0.1, "inches"), arrow_ends = "last", arrow_type = "closed", title = NULL, title_x = 0.5, title_y = 0.9, title_color = "black", title_fs = 15, title_fface = 2, title_ffamily = NULL, canvas_bg = "white") {
 
   is_class(object, "fc")
   UseMethod("fc_draw")
@@ -39,7 +40,7 @@ fc_draw <- function(object, big.mark = "", box_corners = "round", arrow_angle = 
 #' @importFrom rlang .data
 #' @export
 
-fc_draw.fc <- function(object, big.mark = "", box_corners = "round", arrow_angle = 30, arrow_length = grid::unit(0.1, "inches"), arrow_ends = "last", arrow_type = "closed", title = NULL, title_x = 0.5, title_y = 0.9, title_color = "black", title_fs = 15, title_fface = 2, title_ffamily = NULL) {
+fc_draw.fc <- function(object, big.mark = "", box_corners = "round", arrow_angle = 30, arrow_length = grid::unit(0.1, "inches"), arrow_ends = "last", arrow_type = "closed", title = NULL, title_x = 0.5, title_y = 0.9, title_color = "black", title_fs = 15, title_fface = 2, title_ffamily = NULL, canvas_bg = "white") {
 
   # Check for valid corners argument
   if (!box_corners %in% c("round", "sharp")) {
@@ -55,10 +56,15 @@ fc_draw.fc <- function(object, big.mark = "", box_corners = "round", arrow_angle
   #Initialize grid
   grid::grid.newpage()
 
+  # Draw background rectangle covering the entire viewport
+  if (canvas_bg != "transparent" && !is.null(canvas_bg)) {
+    grid::grid.rect(gp = grid::gpar(fill = canvas_bg, col = NA))
+  }
+
   object0 <- object #to return the object unaltered
 
   #We have to return the parameters of the function in the attribute of object$fc
-  params <- c("arrow_angle", "arrow_length", "arrow_ends", "arrow_type")
+  params <- c("arrow_angle", "arrow_length", "arrow_ends", "arrow_type", "canvas_bg")
   attr_draw <- purrr::map(params, ~get(.x))
   names(attr_draw) <- params
 

--- a/R/fc_draw.R
+++ b/R/fc_draw.R
@@ -15,7 +15,7 @@
 #' @param title_fs Font size of the title. It is 15 by default. See the `fontsize` parameter for \code{\link{gpar}}.
 #' @param title_fface Font face of the title. It is 2 by default. See the `fontface` parameter for \code{\link{gpar}}.
 #' @param title_ffamily Changes the font family of the title. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}.
-#' @param canvas_bg Background color for the entire canvas (the area behind the flowchart boxes). Default is `"white"`. Set to `"transparent"` or `NULL` for a transparent background (compatible with all `fc_export()` formats except `"jpeg"` and `"bmp"`).
+#' @param canvas_bg Background color for the entire canvas (the area behind the flowchart boxes). Default is `"white"`. Set to `"transparent"` or `NULL` for a transparent background; `"transparent"` background will only be noticeable when exporting drawn flowcharts via `fc_export()` and is compatible with all `fc_export()` formats except `"jpeg"` and `"bmp"`.
 
 #' @return Invisibly returns the same object that has been given to the function, with the given arguments to draw the flowchart stored in the attributes.
 #'

--- a/R/fc_export.R
+++ b/R/fc_export.R
@@ -211,7 +211,7 @@ fc_export.fc <- function(object, filename, path = NULL, format = NULL, width = N
       } else {
         # JPEG and bmp does not support transparency - warn user and fallback on device default
         device_fun(filename = filename, width = width, height = height, units = units, res = res)
-        warning(" \"jpeg\" and \"bmp\" formats do not support transparent `canvas_bg`, falling back to \"white\"")
+        cli::cli_warn("The formats {.val jpeg} and {.val bmp} do not support transparent {.arg canvas_bg}, falling back to {.val white}")
       }
     } else {
       # Normal case with a background color ("white" or otherwise)

--- a/R/fc_export.R
+++ b/R/fc_export.R
@@ -139,21 +139,24 @@ fc_export.fc <- function(object, filename, path = NULL, format = NULL, width = N
       grDevices::svg(
         filename = filename,
         width = width_in,
-        height = height_in
+        height = height_in,
+        bg = params$canvas_bg  # Original default for grDevices::svg() is "white"
       )
     } else if (format == "pdf") {
       if (capabilities("cairo")) {
         grDevices::cairo_pdf(
           filename = filename,
           width = width_in,
-          height = height_in
+          height = height_in,
+          bg = params$canvas_bg  # Original default for grDevices::pdf() is "white"
         )
       } else {
         cli::cli_warn("Cairo graphics library is not available. Falling back to {.fn grDevices::pdf}.")
         grDevices::pdf(
           file = filename,
           width = width_in,
-          height = height_in
+          height = height_in,
+          bg = params$canvas_bg    # Original default for grDevices::pdf() is "transparent"
         )
       }
     }
@@ -199,12 +202,26 @@ fc_export.fc <- function(object, filename, path = NULL, format = NULL, width = N
     } else {
       device_fun <- switch(format, bmp = grDevices::bmp)
     }
-    device_fun(filename = filename, width = width, height = height, units = units, res = res)
+
+    # If canvas_bg == "transparent" or NULL and bitmap format supports transparency, set to "transparent"
+    if (params$canvas_bg == "transparent" || is.null(params$canvas_bg)) {
+      # Add transparency support for PNG and TIFF
+      if (format %in% c("png", "tiff")) {
+        device_fun(filename = filename, width = width, height = height, units = units, res = res, bg = "transparent")
+      } else {
+        # JPEG and bmp does not support transparency - warn user and fallback on device default
+        device_fun(filename = filename, width = width, height = height, units = units, res = res)
+        warning(" \"jpeg\" and \"bmp\" formats do not support transparent `canvas_bg`, falling back to \"white\"")
+      }
+    } else {
+      # Normal case with a background color ("white" or otherwise)
+      device_fun(filename = filename, width = width, height = height, units = units, res = res, bg = params$canvas_bg)
+    }
   }
 
   #Redraw the plot
   object |>
-    fc_draw(arrow_angle = params$arrow_angle, arrow_length = params$arrow_length, arrow_ends = params$arrow_ends, arrow_type = params$arrow_type)
+    fc_draw(arrow_angle = params$arrow_angle, arrow_length = params$arrow_length, arrow_ends = params$arrow_ends, arrow_type = params$arrow_type, canvas_bg = params$canvas_bg)
 
   grDevices::dev.off()
 

--- a/man/fc_draw.Rd
+++ b/man/fc_draw.Rd
@@ -51,7 +51,7 @@ fc_draw(
 
 \item{title_ffamily}{Changes the font family of the title. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}.}
 
-\item{canvas_bg}{Background color for the entire canvas (the area behind the flowchart boxes). Default is `"white"`. Set to `"transparent"` or `NULL` for a transparent background (compatible with all `fc_export()` formats except `"jpeg"` and `"bmp"`).}
+\item{canvas_bg}{Background color for the entire canvas (the area behind the flowchart boxes). Default is `"white"`. Set to `"transparent"` or `NULL` for a transparent background; `"transparent"` background will only be noticeable when exporting drawn flowcharts via `fc_export()` and is compatible with all `fc_export()` formats except `"jpeg"` and `"bmp"`.}
 }
 \value{
 Invisibly returns the same object that has been given to the function, with the given arguments to draw the flowchart stored in the attributes.

--- a/man/fc_draw.Rd
+++ b/man/fc_draw.Rd
@@ -18,7 +18,8 @@ fc_draw(
   title_color = "black",
   title_fs = 15,
   title_fface = 2,
-  title_ffamily = NULL
+  title_ffamily = NULL,
+  canvas_bg = "white"
 )
 }
 \arguments{
@@ -49,6 +50,8 @@ fc_draw(
 \item{title_fface}{Font face of the title. It is 2 by default. See the `fontface` parameter for \code{\link{gpar}}.}
 
 \item{title_ffamily}{Changes the font family of the title. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}.}
+
+\item{canvas_bg}{Background color for the entire canvas (the area behind the flowchart boxes). Default is `"white"`. Set to `"transparent"` or `NULL` for a transparent background (compatible with all `fc_export()` formats except `"jpeg"` and `"bmp"`).}
 }
 \value{
 Invisibly returns the same object that has been given to the function, with the given arguments to draw the flowchart stored in the attributes.


### PR DESCRIPTION
@pasahe I made the following changes independent of the other PR I submitted recently.

1. Added the `canvas_bg` argument to `fc_draw()` to allow the user to specify a canvas background color other than "white", with the option to set it to "transparent".
    a. Default set to `"white"`, so should not cause any breaking changes
3. Updated `fc_export()` to use the `canvas_bg` option supplied by `fc_draw()` so that the exported image canvas background matches the specified `canvas_bg` argument. I included a warning for the user if they try to set `canvas_bg = "transparent"` for `format = "jpeg"` or `format = "bmp"` to inform them that those formats are not compatible with transparent backgrounds.

Closes #30 


## Examples

### Original example

```
safo |>
  as_fc(label = "Patients assessed for eligibility") |>
  fc_filter(!is.na(group), label = "Randomized", show_exc = TRUE) |>
  fc_draw() |>
  fc_export("flowchart.png")
```
![flowchart](https://github.com/user-attachments/assets/ad1b9c26-6c65-4857-8fc5-b67c09275152)

### Transparent background

```
safo |>
  as_fc(label = "Patients assessed for eligibility") |>
  fc_filter(!is.na(group), label = "Randomized", show_exc = TRUE) |>
  fc_draw(canvas_bg = "transparent") |>
  fc_export("flowchart_transparent.png")
```
  
![flowchart_transparent](https://github.com/user-attachments/assets/6aff8fcf-c292-4941-93eb-461102726f9a)


### Non-white, non-transparent background example

```
safo |>
  as_fc(label = "Patients assessed for eligibility") |>
  fc_filter(!is.na(group), label = "Randomized", show_exc = TRUE) |>
  fc_draw(canvas_bg = "green") |>
  fc_export("flowchart_green.png")
```
![flowchart_green](https://github.com/user-attachments/assets/339c60a8-9b87-4aa4-9c69-d06634f51441)

