### PR TITLE
`fc_export()` bug fix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-1462-379X")),
     person("Cristian", "Tebé", role = "aut",
            comment = c(ORCID = "0000-0003-2320-1385")),
-    person("Kenneth", "Taylor", role = "ctb",
+    person("Kenneth", "Taylor", role = "aut",
            comment = c(ORCID = "0000-0002-3205-9280"))
   )
 Maintainer: Pau Satorra <psatorra@igtp.cat>

--- a/NEWS.md
+++ b/NEWS.md
@@ -111,3 +111,5 @@
 * Updated `fc_draw()` with `canvas_bg` argument which allows the user to specify the flowchart canvas background color or to set it to `"transparent"` (#30; @kenkomodo)
 
 * Updated `fc_export()` to accept the new `canvas_bg` argument from `fc_draw()` and apply it accordingly to the exported flowchart image (#30; @kenkomodo)
+
+* Solved `bug` causing `fc_export()` to drop newer `fc_draw()` arguments when redrawing the flowchart for export (#32; @kenkomodo)

--- a/R/fc_draw.R
+++ b/R/fc_draw.R
@@ -64,7 +64,7 @@ fc_draw.fc <- function(object, big.mark = "", box_corners = "round", arrow_angle
   object0 <- object #to return the object unaltered
 
   #We have to return the parameters of the function in the attribute of object$fc
-  params <- c("arrow_angle", "arrow_length", "arrow_ends", "arrow_type", "canvas_bg")
+  params <- c("big.mark", "box_corners", "arrow_angle", "arrow_length", "arrow_ends", "arrow_type", "title", "title_x", "title_y", "title_color", "title_fs", "title_fface", "title_ffamily", "canvas_bg")
   attr_draw <- purrr::map(params, ~get(.x))
   names(attr_draw) <- params
 

--- a/R/fc_export.R
+++ b/R/fc_export.R
@@ -221,7 +221,7 @@ fc_export.fc <- function(object, filename, path = NULL, format = NULL, width = N
 
   #Redraw the plot
   object |>
-    fc_draw(arrow_angle = params$arrow_angle, arrow_length = params$arrow_length, arrow_ends = params$arrow_ends, arrow_type = params$arrow_type, canvas_bg = params$canvas_bg)
+    fc_draw(big.mark = params$big.mark, box_corners = params$box_corners, arrow_angle = params$arrow_angle, arrow_length = params$arrow_length, arrow_ends = params$arrow_ends, arrow_type = params$arrow_type, title = params$title, title_x = params$title_x, title_y = params$title_y, title_color = params$title_color, title_fs = params$title_fs, title_fface = params$title_fface, title_ffamily = params$title_ffamily, canvas_bg = params$canvas_bg)
 
   grDevices::dev.off()
 


### PR DESCRIPTION
Fixes #32.

* Updated `fc_draw()` to output all current arguments into `params` to pass for use in `fc_export()`
* Updated `fc_export()` to use all current `fc_draw()` arguments passed via `params`