### PR TITLE
Added arrow options

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,7 @@ VignetteBuilder: knitr
 Depends: 
     R (>= 4.1.0)
 RoxygenNote: 7.3.2
+Roxygen: list(markdown = TRUE)
 URL: https://bruigtp.github.io/flowchart/
 Config/testthat/edition: 3
 Config/Needs/website: rmarkdown

--- a/NEWS.md
+++ b/NEWS.md
@@ -131,3 +131,5 @@
 * Stack flowcharts with `unite=TRUE` if there are more boxes in the last level of the first flowchart than in the first level of the second flowchart.
 
 * Fixed `bug` allowing trailing zeros to be trimmed regardless of `round_digits` argument in `fc_filter()` and `fc_split()` (@kenkomodo)
+
+* Updated `fc_draw()` with arguments to control arrow shape and color: `arrow_color`, `arrow_lwd`, `arrow_lineend`, and `arrow_linejoin`. Updated `fc_export()` to use new arguments for flowchart image export. (#43; @kenkomodo)

--- a/R/as_fc.R
+++ b/R/as_fc.R
@@ -2,20 +2,20 @@
 #' @description This function allows to initialize a flow chart given any database. It will create a fc object showing the number of rows of the database. If a database is not available, the user can instead directly enter the number of rows in the study.
 #'
 #' @param .data Data frame to be initialised as a flowchart.
-#' @param N Number of rows of the study in case `.data` is NULL.
+#' @param N Number of rows of the study in case `.data` is `NULL`.
 #' @param label Character or expression with the text that will be shown in the box.
-#' @param text_pattern Character or expression defining the structure that will have the text in each of the boxes. It recognizes label, n, N and perc within brackets. For default it is "\{label\}\\n \{n\}". If text_pattern or label is an expression, the label is always placed at the beginning of the pattern, followed by a line break where the structure specified by text_pattern is placed.
+#' @param text_pattern Character or expression defining the structure that will have the text in each of the boxes. It recognizes `label`, `n`, `N` and `perc` within brackets. For default it is `"{label}\n {n}"`. If `text_pattern` or `label` is an expression, the `label` is always placed at the beginning of the pattern, followed by a line break where the structure specified by `text_pattern` is placed.
 #' @param just Justification for the text: left, center or right. Default is center.
-#' @param text_color Color of the text. It is black by default. See the `col` parameter for \code{\link{gpar}}.
-#' @param text_fs Font size of the text. It is 8 by default. See the `fontsize` parameter for \code{\link{gpar}}.
-#' @param text_fface Font face of the text. It is 1 by default. See the `fontface` parameter for \code{\link{gpar}}.
-#' @param text_ffamily Changes the font family of the text. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}.
+#' @param text_color Color of the text. It is `"black"` by default. See the `col` parameter for [gpar].
+#' @param text_fs Font size of the text. It is 8 by default. See the `fontsize` parameter for [gpar].
+#' @param text_fface Font face of the text. It is 1 by default. See the `fontface` parameter for [gpar].
+#' @param text_ffamily Changes the font family of the text. Default is `NA`. See the `fontfamily` parameter for [gpar].
 #' @param text_padding Changes the text padding inside the box. Default is 1. This number has to be greater than 0.
-#' @param bg_fill Box background color. It is white by default. See the `fill` parameter for \code{\link{gpar}}.
-#' @param border_color Box border color. It is black by default. See the `col` parameter for \code{\link{gpar}}.
-#' @param width Width of the box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.
-#' @param height Height of the box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.
-#' @param hide Logical value to hide the initial box or not. Default is FALSE. hide = TRUE can only be combined with fc_split().
+#' @param bg_fill Box background color. It is white by default. See the `fill` parameter for [gpar].
+#' @param border_color Box border color. It is `"black"` by default. See the `col` parameter for [gpar].
+#' @param width Width of the box. If `NA`, it automatically adjusts to the content (default). Must be an object of class [unit] or a number between 0 and 1.
+#' @param height Height of the box. If `NA`, it automatically adjusts to the content (default). Must be an object of class [unit] or a number between 0 and 1.
+#' @param hide Logical value to hide the initial box or not. Default is FALSE. hide = TRUE can only be combined with [fc_split()].
 #'
 #' @return List with the dataset and the initialized flowchart parameters.
 #'

--- a/R/fc_draw.R
+++ b/R/fc_draw.R
@@ -6,16 +6,20 @@
 #' @param box_corners Indicator of whether to draw boxes with round (`"round"`) vs non-round (`"sharp"`) corners. Default is `"round"`.
 #' @param arrow_angle The angle of the arrow head in degrees, as in `arrow`.
 #' @param arrow_length A unit specifying the length of the arrow head (from tip to base), as in `arrow`.
-#' @param arrow_ends One of "last", "first", or "both", indicating which ends of the line to draw arrow heads, as in `arrow`.
-#' @param arrow_type One of "open" or "closed" indicating whether the arrow head should be a closed triangle, as in `arrow`.
-#' @param title The title of the flowchart. Default is NULL (no title).
+#' @param arrow_ends One of `"last"`, `"first"`, or `"both"`, indicating which ends of the line to draw arrow heads, as in [arrow].
+#' @param arrow_type One of `"open"` or `"closed"` indicating whether the arrow head should be a closed triangle, as in [arrow].
+#' @param arrow_color Color of the arrows. Default is `"black"`. See the `col` parameter for [gpar].
+#' @param arrow_lwd Line width of the arrows. Default is 1. See the `lwd` parameter for [gpar].
+#' @param arrow_lineend Line end style for arrows. One of `"round"`, `"butt"`, or `"square"`. Default is `"round"`. See the `lineend` parameter for [gpar].
+#' @param arrow_linejoin Line join style for arrow heads (i.e., shape of arrow head corners). One of `"round"`, `"mitre"`, or `"bevel"`. Default is `"round"`. See the `linejoin` parameter for [gpar].
+#' @param title The title of the flowchart. Default is `NULL` (no title).
 #' @param title_x x coordinate for the title. Default is 0.5.
 #' @param title_y y coordinate for the title. Default is 0.9.
-#' @param title_color Color of the title. It is black by default. See the `col` parameter for \code{\link{gpar}}.
-#' @param title_fs Font size of the title. It is 15 by default. See the `fontsize` parameter for \code{\link{gpar}}.
-#' @param title_fface Font face of the title. It is 2 by default. See the `fontface` parameter for \code{\link{gpar}}.
-#' @param title_ffamily Changes the font family of the title. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}.
-#' @param canvas_bg Background color for the entire canvas (the area behind the flowchart boxes). Default is `"white"`. Set to `"transparent"` or `NULL` for a transparent background; `"transparent"` background will only be noticeable when exporting drawn flowcharts via `fc_export()` and is compatible with all `fc_export()` formats except `"jpeg"` and `"bmp"`.
+#' @param title_color Color of the title. It is `"black"` by default. See the `col` parameter for [gpar].
+#' @param title_fs Font size of the title. It is 15 by default. See the `fontsize` parameter for [gpar].
+#' @param title_fface Font face of the title. It is 2 by default. See the `fontface` parameter for [gpar].
+#' @param title_ffamily Changes the font family of the title. Default is `NA`. See the `fontfamily` parameter for [gpar].
+#' @param canvas_bg Background color for the entire canvas (the area behind the flowchart boxes). Default is `"white"`. Set to `"transparent"` or `NULL` for a transparent background; `"transparent"` background will only be noticeable when exporting drawn flowcharts via [fc_export()] and is compatible with all [fc_export()] formats except `"jpeg"` and `"bmp"`.
 
 #' @return Invisibly returns the same object that has been given to the function, with the given arguments to draw the flowchart stored in the attributes.
 #'
@@ -30,7 +34,7 @@
 #'
 #' @export
 
-fc_draw <- function(object, big.mark = "", box_corners = "round", arrow_angle = 30, arrow_length = grid::unit(0.1, "inches"), arrow_ends = "last", arrow_type = "closed", title = NULL, title_x = 0.5, title_y = 0.9, title_color = "black", title_fs = 15, title_fface = 2, title_ffamily = NULL, canvas_bg = "white") {
+fc_draw <- function(object, big.mark = "", box_corners = "round", arrow_angle = 30, arrow_length = grid::unit(0.1, "inches"), arrow_ends = "last", arrow_type = "closed", arrow_color = "black", arrow_lwd = 1, arrow_lineend = "round", arrow_linejoin = "round", title = NULL, title_x = 0.5, title_y = 0.9, title_color = "black", title_fs = 15, title_fface = 2, title_ffamily = NULL, canvas_bg = "white") {
 
   is_class(object, "fc")
   UseMethod("fc_draw")
@@ -40,7 +44,7 @@ fc_draw <- function(object, big.mark = "", box_corners = "round", arrow_angle = 
 #' @importFrom rlang .data
 #' @export
 
-fc_draw.fc <- function(object, big.mark = "", box_corners = "round", arrow_angle = 30, arrow_length = grid::unit(0.1, "inches"), arrow_ends = "last", arrow_type = "closed", title = NULL, title_x = 0.5, title_y = 0.9, title_color = "black", title_fs = 15, title_fface = 2, title_ffamily = NULL, canvas_bg = "white") {
+fc_draw.fc <- function(object, big.mark = "", box_corners = "round", arrow_angle = 30, arrow_length = grid::unit(0.1, "inches"), arrow_ends = "last", arrow_type = "closed", arrow_color = "black", arrow_lwd = 1, arrow_lineend = "round", arrow_linejoin = "round", title = NULL, title_x = 0.5, title_y = 0.9, title_color = "black", title_fs = 15, title_fface = 2, title_ffamily = NULL, canvas_bg = "white") {
 
   # Check for valid corners argument
   if (!box_corners %in% c("round", "sharp")) {
@@ -51,6 +55,14 @@ fc_draw.fc <- function(object, big.mark = "", box_corners = "round", arrow_angle
     rect_type <- grid::roundrectGrob
   } else {
     rect_type <- grid::rectGrob
+  }
+
+  if (!(arrow_lineend %in% c("round", "butt", "square"))) {
+    cli::cli_abort("The {.arg arrow_lineend} argument must be {.val round}, {.val butt}, or {.val square}")
+  }
+
+  if (!(arrow_linejoin %in% c("round", "mitre", "bevel"))) {
+    cli::cli_abort("The {.arg arrow_linejoin} argument must be {.val round}, {.val mitre}, or {.val bevel}")
   }
 
   #Initialize grid
@@ -64,7 +76,7 @@ fc_draw.fc <- function(object, big.mark = "", box_corners = "round", arrow_angle
   object0 <- object #to return the object unaltered
 
   #We have to return the parameters of the function in the attribute of object$fc
-  params <- c("big.mark", "box_corners", "arrow_angle", "arrow_length", "arrow_ends", "arrow_type", "title", "title_x", "title_y", "title_color", "title_fs", "title_fface", "title_ffamily", "canvas_bg")
+  params <- c("big.mark", "box_corners", "arrow_angle", "arrow_length", "arrow_ends", "arrow_type", "arrow_color", "arrow_lwd", "arrow_lineend", "arrow_linejoin", "title", "title_x", "title_y", "title_color", "title_fs", "title_fface", "title_ffamily", "canvas_bg")
   attr_draw <- purrr::map(params, ~get(.x))
   names(attr_draw) <- params
 
@@ -154,7 +166,7 @@ fc_draw.fc <- function(object, big.mark = "", box_corners = "round", arrow_angle
 
             #If it exists because now the initial box can be hided
             if(length(id_par) > 0) {
-              print(Gmisc::connectGrob(plot_fc[[i]]$bg[[id_par]], plot_fc[[i]]$bg[[k]], type = "N", arrow_obj = getOption("connectGrobArrow", default = grid::arrow(angle = arrow_angle, length = arrow_length, ends = arrow_ends, type = arrow_type))))
+              print(Gmisc::connectGrob(plot_fc[[i]]$bg[[id_par]], plot_fc[[i]]$bg[[k]], type = "N", lty_gp = getOption("connectGrob", default = grid::gpar(col = arrow_color, fill = arrow_color, lwd = arrow_lwd, lineend = arrow_lineend, linejoin = arrow_linejoin)), arrow_obj = getOption("connectGrobArrow", default = grid::arrow(angle = arrow_angle, length = arrow_length, ends = arrow_ends, type = arrow_type))))
             }
 
           }
@@ -171,7 +183,7 @@ fc_draw.fc <- function(object, big.mark = "", box_corners = "round", arrow_angle
 
             #If it exists because now the initial box can be hided
             if(length(id) > 0) {
-              print(Gmisc::connectGrob(plot_fc[[i]]$bg[[id]], plot_fc[[i]]$bg[[k]], type = "vertical", arrow_obj = getOption("connectGrobArrow", default = grid::arrow(angle = arrow_angle, length = arrow_length, ends = arrow_ends, type = arrow_type))))
+              print(Gmisc::connectGrob(plot_fc[[i]]$bg[[id]], plot_fc[[i]]$bg[[k]], type = "vertical", lty_gp = getOption("connectGrob", default = grid::gpar(col = arrow_color, fill = arrow_color, lwd = arrow_lwd, lineend = arrow_lineend, linejoin = arrow_linejoin)), arrow_obj = getOption("connectGrobArrow", default = grid::arrow(angle = arrow_angle, length = arrow_length, ends = arrow_ends, type = arrow_type))))
             }
 
           }
@@ -180,7 +192,7 @@ fc_draw.fc <- function(object, big.mark = "", box_corners = "round", arrow_angle
 
           for(k in ids) {
 
-            print(Gmisc::connectGrob(plot_fc[[i]]$bg[[k - 1]], plot_fc[[i]]$bg[[k]], type = "-", arrow_obj = getOption("connectGrobArrow", default = grid::arrow(angle = arrow_angle, length = arrow_length, ends = arrow_ends, type = arrow_type))))
+            print(Gmisc::connectGrob(plot_fc[[i]]$bg[[k - 1]], plot_fc[[i]]$bg[[k]], type = "-", lty_gp = getOption("connectGrob", default = grid::gpar(col = arrow_color, fill = arrow_color, lwd = arrow_lwd, lineend = arrow_lineend, linejoin = arrow_linejoin)), arrow_obj = getOption("connectGrobArrow", default = grid::arrow(angle = arrow_angle, length = arrow_length, ends = arrow_ends, type = arrow_type))))
 
           }
 
@@ -197,7 +209,7 @@ fc_draw.fc <- function(object, big.mark = "", box_corners = "round", arrow_angle
 
             for(k in ids) {
 
-              print(Gmisc::connectGrob(plot_fc[[i]]$bg[[id_last]], plot_fc[[i]]$bg[[k]], type = "N", arrow_obj = getOption("connectGrobArrow", default = grid::arrow(angle = arrow_angle, length = arrow_length, ends = arrow_ends, type = arrow_type))))
+              print(Gmisc::connectGrob(plot_fc[[i]]$bg[[id_last]], plot_fc[[i]]$bg[[k]], type = "N", lty_gp = getOption("connectGrob", default = grid::gpar(col = arrow_color, fill = arrow_color, lwd = arrow_lwd, lineend = arrow_lineend, linejoin = arrow_linejoin)), arrow_obj = getOption("connectGrobArrow", default = grid::arrow(angle = arrow_angle, length = arrow_length, ends = arrow_ends, type = arrow_type))))
 
             }
 
@@ -205,7 +217,7 @@ fc_draw.fc <- function(object, big.mark = "", box_corners = "round", arrow_angle
 
             for(k in id_last) {
 
-              print(Gmisc::connectGrob(plot_fc[[i]]$bg[[k]], plot_fc[[i]]$bg[[ids]], type = "L", arrow_obj = getOption("connectGrobArrow", default = grid::arrow(angle = arrow_angle, length = arrow_length, ends = arrow_ends, type = arrow_type))))
+              print(Gmisc::connectGrob(plot_fc[[i]]$bg[[k]], plot_fc[[i]]$bg[[ids]], type = "L", lty_gp = getOption("connectGrob", default = grid::gpar(col = arrow_color, fill = arrow_color, lwd = arrow_lwd, lineend = arrow_lineend, linejoin = arrow_linejoin)), arrow_obj = getOption("connectGrobArrow", default = grid::arrow(angle = arrow_angle, length = arrow_length, ends = arrow_ends, type = arrow_type))))
 
             }
 
@@ -214,7 +226,7 @@ fc_draw.fc <- function(object, big.mark = "", box_corners = "round", arrow_angle
             #They have the same number of boxes
             for(k in 1:length(ids)) {
               #vertical connection
-              print(Gmisc::connectGrob(plot_fc[[i]]$bg[[id_last[k]]], plot_fc[[i]]$bg[[ids[k]]], type = "vertical", arrow_obj = getOption("connectGrobArrow", default = grid::arrow(angle = arrow_angle, length = arrow_length, ends = arrow_ends, type = arrow_type))))
+              print(Gmisc::connectGrob(plot_fc[[i]]$bg[[id_last[k]]], plot_fc[[i]]$bg[[ids[k]]], type = "vertical", lty_gp = getOption("connectGrob", default = grid::gpar(col = arrow_color, fill = arrow_color, lwd = arrow_lwd, lineend = arrow_lineend, linejoin = arrow_linejoin)), arrow_obj = getOption("connectGrobArrow", default = grid::arrow(angle = arrow_angle, length = arrow_length, ends = arrow_ends, type = arrow_type))))
             }
 
           } else {

--- a/R/fc_export.R
+++ b/R/fc_export.R
@@ -1,13 +1,13 @@
 #' @title fc_export
-#' @description This function allows you to export the drawn flowchart to the most popular graphic formats, including bitmap formats (png, jpeg, tiff, bmp) and vector formats (svg, pdf). For bitmap formats, it uses the [ragg] package devices when available for higher performance and higher quality output than standard raster devices provide by [grDevices].
+#' @description This function allows you to export the drawn flowchart to the most popular graphic formats, including bitmap formats (png, jpeg, tiff, bmp) and vector formats (svg, pdf). For bitmap formats, it uses the [ragg](https://ragg.r-lib.org/) package devices when available for higher performance and higher quality output than standard raster devices provide by [grDevices].
 #'
 #' @details
 #'
 #' - **Vector Formats (`'svg'`, `'pdf'`):** These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies `units` other than inches (`"mm"` or` "cm"`), the function will convert the dimensions to inches using standard conversion formulas.
 #'
-#' - **Bitmap Formats (`'png'`, `'jpeg'`, `'tiff'`, `'bmp'`):** For these formats (with the exception of `"bmp"`), the function uses the [ragg] package devices when available, providing higher performance and higher quality output. The default `units` for `width` and `height` are pixels.
+#' - **Bitmap Formats (`'png'`, `'jpeg'`, `'tiff'`, `'bmp'`):** For these formats (with the exception of `"bmp"`), the function uses the [ragg](https://ragg.r-lib.org/) package devices when available, providing higher performance and higher quality output. The default `units` for `width` and `height` are pixels.
 #'
-#' - **Suggested Dependencies:** For superior performance and quality bitmap outputs, it is recommended to install the [ragg] package. For exporting to `"pdf"` format with enhanced features, the Cairo graphics library will be used if it is available.
+#' - **Suggested Dependencies:** For superior performance and quality bitmap outputs, it is recommended to install the [ragg](https://ragg.r-lib.org/) package. For exporting to `"pdf"` format with enhanced features, the Cairo graphics library will be used if it is available.
 #'
 #' @param object fc object that we want to export.
 #' @param filename File name to create on disk.

--- a/R/fc_export.R
+++ b/R/fc_export.R
@@ -1,19 +1,22 @@
 #' @title fc_export
-#' @description This function allows you to export the drawn flowchart to the most popular graphic formats, including bitmap formats (png, jpeg, tiff, bmp) and vector formats (svg, pdf). For bitmap formats, it uses the `ragg` package devices when available for higher performance and higher quality output than standard raster devices provide by `grDevices`.
+#' @description This function allows you to export the drawn flowchart to the most popular graphic formats, including bitmap formats (png, jpeg, tiff, bmp) and vector formats (svg, pdf). For bitmap formats, it uses the [ragg] package devices when available for higher performance and higher quality output than standard raster devices provide by [grDevices].
 #'
 #' @details
-#' - **Vector Formats ('svg', 'pdf'):** These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies `units` other than inches ("mm" or "cm"), the function will convert the dimensions to inches using standard conversion formulas.
-#' - **Bitmap Formats ('png', 'jpeg', 'tiff', 'bmp'):** For these formats (with the exception of 'bmp'), the function uses the `ragg` package devices when available, providing higher performance and higher quality output. The default units for width and height are pixels.
-#' - **Suggested Dependencies:** For superior performance and quality bitmap outputs, it is recommended to install the `ragg` package. For exporting to 'pdf' format with enhanced features, the Cairo graphics library will be used if it is available.
+#'
+#' - **Vector Formats (`'svg'`, `'pdf'`):** These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies `units` other than inches (`"mm"` or` "cm"`), the function will convert the dimensions to inches using standard conversion formulas.
+#'
+#' - **Bitmap Formats (`'png'`, `'jpeg'`, `'tiff'`, `'bmp'`):** For these formats (with the exception of `"bmp"`), the function uses the [ragg] package devices when available, providing higher performance and higher quality output. The default `units` for `width` and `height` are pixels.
+#'
+#' - **Suggested Dependencies:** For superior performance and quality bitmap outputs, it is recommended to install the [ragg] package. For exporting to `"pdf"` format with enhanced features, the Cairo graphics library will be used if it is available.
 #'
 #' @param object fc object that we want to export.
 #' @param filename File name to create on disk.
 #' @param path Path of the directory to save plot to: path and filename are combined to create the fully qualified file name. Defaults to the working directory.
-#' @param format Name of the graphic device. One of 'png', 'jpeg', 'tiff', 'bmp', 'svg', or 'pdf'. If `NULL` (default), the format is guessed based on the filename extension.
+#' @param format Name of the graphic device. One of `"png"`, `"jpeg"`, `"tiff"`, `"bmp"`, `"svg"`, or `"pdf"`. If `NULL` (default), the format is guessed based on the filename extension.
 #' @param width,height Plot size in units expressed by the `units` argument. Default is 600px for bitmap formats and 6 inches for vector formats.
-#' @param units One of the following units in which the width and height arguments are expressed: "in", "cm", "mm" for vector formats and "in", "cm", "mm" or "px" for bitmap formats. If left `NULL` (default), the function will automatically use "px" for bitmap formats and "in" for vector formats.
+#' @param units One of the following units in which the width and height arguments are expressed: `"in"`, `"cm"`, `"mm"` for vector formats and `"in"`, `"cm"`, `"mm"` or `"px"` for bitmap formats. If left `NULL` (default), the function will automatically use `"px"` for bitmap formats and `"in"` for vector formats.
 #' @param res The nominal resolution in ppi which will be recorded in the bitmap file, if a positive integer. Also used for units other than the default, and to convert points to pixels. Default is 100 if exporting in bitmap format. This argument is unused if exporting to a vector format.
-#' @param ... Arguments to be passed to the device function used to save the flowchart. The available parameters will differ depending on the format (e.g., \code{\link{png}}).
+#' @param ... Arguments to be passed to the device function used to save the flowchart. The available parameters will differ depending on the format (e.g., [png]).
 #'
 #' @return Invisibly returns the same object that has been given to the function.
 #'
@@ -242,7 +245,7 @@ fc_export.fc <- function(object, filename, path = NULL, format = NULL, width = N
 
   #Redraw the plot
   object |>
-    fc_draw(big.mark = params$big.mark, box_corners = params$box_corners, arrow_angle = params$arrow_angle, arrow_length = params$arrow_length, arrow_ends = params$arrow_ends, arrow_type = params$arrow_type, title = params$title, title_x = params$title_x, title_y = params$title_y, title_color = params$title_color, title_fs = params$title_fs, title_fface = params$title_fface, title_ffamily = params$title_ffamily, canvas_bg = params$canvas_bg)
+    fc_draw(big.mark = params$big.mark, box_corners = params$box_corners, arrow_angle = params$arrow_angle, arrow_length = params$arrow_length, arrow_ends = params$arrow_ends, arrow_type = params$arrow_type, arrow_color = params$arrow_color, arrow_lwd = params$arrow_lwd, arrow_lineend = params$arrow_lineend, arrow_linejoin = params$arrow_linejoin, title = params$title, title_x = params$title_x, title_y = params$title_y, title_color = params$title_color, title_fs = params$title_fs, title_fface = params$title_fface, title_ffamily = params$title_ffamily, canvas_bg = params$canvas_bg)
 
   grDevices::dev.off()
 

--- a/R/fc_filter.R
+++ b/R/fc_filter.R
@@ -3,38 +3,38 @@
 #'
 #' @param object fc object that we want to filter.
 #' @param filter Expression that returns a logical value and are defined in terms of the variables in the data frame. The data base will be filtered by this expression, and it will create a box showing the number of rows satisfying this condition.
-#' @param N Number of rows after the filter in case `filter` is NULL.
+#' @param N Number of rows after the filter in case `filter` is `NULL`.
 #' @param label Character or expression that will be the title of the box. By default it will be the evaluated condition.
-#' @param text_pattern Character or expression defining the structure that will have the text in each of the boxes. It recognizes label, n, N and perc within brackets. For default it is "\{label\}\\n \{n\} (\{perc\}\%)". If text_pattern or label is an expression, the label is always placed at the beginning of the pattern, followed by a line break where the structure specified by text_pattern is placed.
-#' @param perc_total logical. Should percentages be calculated using the total number of rows at the beginning of the flowchart? Default is FALSE, meaning that they will be calculated using the number at the parent leaf.
-#' @param show_exc Logical value. If TRUE a box showing the number of excluded rows will be added to the flow chart.
-#' @param direction_exc One of "left" or "right" indicating if the exclusion box goes into the left direction or in the right direction. By default is "right".
+#' @param text_pattern Character or expression defining the structure that will have the text in each of the boxes. It recognizes `label`, `n`, `N` and `perc` within brackets. For default it is `"{label}\n {n} ({perc}%)"`. If `text_pattern` or `label` is an expression, the `label` is always placed at the beginning of the pattern, followed by a line break where the structure specified by `text_pattern` is placed.
+#' @param perc_total logical. Should percentages be calculated using the total number of rows at the beginning of the flowchart? Default is `FALSE`, meaning that they will be calculated using the number at the parent leaf.
+#' @param show_exc Logical value. If `TRUE` a box showing the number of excluded rows will be added to the flow chart.
+#' @param direction_exc One of `"left"` or `"right"` indicating if the exclusion box goes into the left direction or in the right direction. By default is `"right"`.
 #' @param label_exc Character or expression that will be the title of the added box showing the excluded patients. By default it will show "Excluded".
-#' @param text_pattern_exc Character or expression defining the structure that will have the text in the exclude box. It recognizes label, n, N and perc within brackets. For default it is "\{label\}\\n \{n\} (\{perc\}\%)". If text_pattern or label is an expression, the label is always placed at the beginning of the pattern, followed by a line break where the structure specified by text_pattern_exc is placed.
-#' @param sel_group Select the group in which to perform the filter. The default is NULL. Can only be used if the flowchart has previously been split. If the flowchart has more than one group, it can either be given the full name as it is stored in the `$fc` component (separated by '\\'), or it can be given as a vector with the names of each group to be selected.
+#' @param text_pattern_exc Character or expression defining the structure that will have the text in the exclude box. It recognizes `label`, `n`, `N` and `perc` within brackets. For default it is `"{label}\n {n} ({perc}%)"`. If text_pattern or label is an expression, the label is always placed at the beginning of the pattern, followed by a line break where the structure specified by `text_pattern_exc` is placed.
+#' @param sel_group Select the group in which to perform the filter. The default is `NULL`. Can only be used if the flowchart has previously been split. If the flowchart has more than one group, it can either be given the full name as it is stored in the `$fc` component (separated by '\\'), or it can be given as a vector with the names of each group to be selected.
 #' @param round_digits Number of digits to round percentages. It is 2 by default.
 #' @param trim_trailing_zeros Logical value. If `TRUE`, allows trailing zeros after the decimal to be trimmed (default is `FALSE`).
-#' @param just Justification for the text: left, center or right. Default is center.
-#' @param text_color Color of the text. It is black by default. See the `col` parameter for \code{\link{gpar}}.
-#' @param text_fs Font size of the text. It is 8 by default. See the `fontsize` parameter for \code{\link{gpar}}.
-#' @param text_fface Font face of the text. It is 1 by default. See the `fontface` parameter for \code{\link{gpar}}.
-#' @param text_ffamily Changes the font family of the text. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}.
+#' @param just Justification for the text: `"left"`, `"center"` or `"right"`. Default is `"center"`.
+#' @param text_color Color of the text. It is `"black"` by default. See the `col` parameter for [gpar].
+#' @param text_fs Font size of the text. It is 8 by default. See the `fontsize` parameter for [gpar].
+#' @param text_fface Font face of the text. It is 1 by default. See the `fontface` parameter for [gpar].
+#' @param text_ffamily Changes the font family of the text. Default is `NA`. See the `fontfamily` parameter for [gpar].
 #' @param text_padding Changes the text padding inside the box. Default is 1. This number has to be greater than 0.
-#' @param bg_fill Box background color. It is white by default. See the `fill` parameter for \code{\link{gpar}}.
-#' @param border_color Box border color. It is black by default. See the `col` parameter for \code{\link{gpar}}.
-#' @param width Width of the box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.
-#' @param height Height of the box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.
-#' @param just_exc Justification for the text of the exclude box: left, center or right. Default is center.
-#' @param text_color_exc Color of the text of the exclude box. It is black by default. See `text_color`.
+#' @param bg_fill Box background color. It is `"white"` by default. See the `fill` parameter for [gpar].
+#' @param border_color Box border color. It is `"black"` by default. See the `col` parameter for [gpar].
+#' @param width Width of the box. If `NA`, it automatically adjusts to the content (default). Must be an object of class [unit] or a number between 0 and 1.
+#' @param height Height of the box. If `NA`, it automatically adjusts to the content (default). Must be an object of class [unit] or a number between 0 and 1.
+#' @param just_exc Justification for the text of the exclude box: `"left"`, `"center"` or `"right"`. Default is `"center"`.
+#' @param text_color_exc Color of the text of the exclude box. It is `"black"` by default. See `text_color`.
 #' @param text_fs_exc Font size of the text of the exclude box. It is 6 by default. See `text_fs`.
-#' @param text_fface_exc Font face of the text of the exclude box. It is 1 by default. See the `fontface` parameter for \code{\link{gpar}}. See `text_fface`.
-#' @param text_ffamily_exc Changes the font family of the text of the exclude box. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}. See `text_ffamily`.
+#' @param text_fface_exc Font face of the text of the exclude box. It is 1 by default. See the `fontface` parameter for [gpar]. See `text_fface`.
+#' @param text_ffamily_exc Changes the font family of the text of the exclude box. Default is `NA`. See the `fontfamily` parameter for [gpar]. See `text_ffamily`.
 #' @param text_padding_exc Changes the text padding inside the exclude box. Default is 1. This number has to be greater than 0.
-#' @param bg_fill_exc Exclude box background color. It is white by default. See `bg_fill`.
-#' @param border_color_exc Box background color of the exclude box. It is black by default. See `border_color`.
-#' @param offset_exc Amount of space to add to the distance between the box and the excluded box (in the x coordinate). If positive, this distance will be larger. If negative, it will be smaller. This number has to be at least between 0 and 1 (plot limits) and the resulting x coordinate cannot exceed these plot limits. The default is NULL (no offset).
-#' @param width_exc Width of the exclude box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.
-#' @param height_exc Height of the box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.
+#' @param bg_fill_exc Exclude box background color. It is `"white"` by default. See `bg_fill`.
+#' @param border_color_exc Box background color of the exclude box. It is `"black"` by default. See `border_color`.
+#' @param offset_exc Amount of space to add to the distance between the box and the excluded box (in the x coordinate). If positive, this distance will be larger. If negative, it will be smaller. This number has to be at least between 0 and 1 (plot limits) and the resulting x coordinate cannot exceed these plot limits. The default is `NULL` (no offset).
+#' @param width_exc Width of the exclude box. If `NA`, it automatically adjusts to the content (default). Must be an object of class [unit] or a number between 0 and 1.
+#' @param height_exc Height of the box. If `NA`, it automatically adjusts to the content (default). Must be an object of class [unit] or a number between 0 and 1.
 #' @return List with the filtered dataset and the flowchart parameters with the resulting filtered box.
 #'
 #' @examples

--- a/R/fc_split.R
+++ b/R/fc_split.R
@@ -3,36 +3,36 @@
 #'
 #' @param object fc object that we want to split.
 #' @param var variable column of the database from which it will be splitted.
-#' @param N Number of rows after the split in case `var` is NULL.
+#' @param N Number of rows after the split in case `var` is `NULL`.
 #' @param label Vector of characters or vector of expressions with the label of each category in order. It has to have as many elements as categories has the column. By default, it will put the labels of the categories.
-#' @param text_pattern Character or expression defining the structure that will have the text in each of the boxes. It recognizes label, n, N and perc within brackets. For default it is "\{label\}\\n \{n\} (\{perc\}\%)". If text_pattern or label is an expression, the label is always placed at the beginning of the pattern, followed by a line break where the structure specified by text_pattern is placed.
-#' @param perc_total logical. Should percentages be calculated using the total number of rows at the beginning of the flowchart? Default is FALSE, meaning that they will be calculated using the number at the parent leaf.
-#' @param sel_group Select the group in which to perform the filter. The default is NULL. Can only be used if the flowchart has previously been split. If the flowchart has more than one group, it can either be given the full name as it is stored in the `$fc` component (separated by '\\'), or it can be given as a vector with the names of each group to be selected.
-#' @param na.rm logical. Should missing values of the grouping variable be removed? Default is FALSE.
-#' @param show_zero logical. Should the levels of the grouping variable that don't have data be shown? Default is FALSE.
+#' @param text_pattern Character or expression defining the structure that will have the text in each of the boxes. It recognizes `label`, `n`, `N` and `perc` within brackets. For default it is `"{label}\n {n} ({perc}%)"`. If `text_pattern` or `label` is an expression, the `label` is always placed at the beginning of the pattern, followed by a line break where the structure specified by `text_pattern` is placed.
+#' @param perc_total logical. Should percentages be calculated using the total number of rows at the beginning of the flowchart? Default is `FALSE`, meaning that they will be calculated using the number at the parent leaf.
+#' @param sel_group Select the group in which to perform the filter. The default is `NULL`. Can only be used if the flowchart has previously been split. If the flowchart has more than one group, it can either be given the full name as it is stored in the `$fc` component (separated by '\\'), or it can be given as a vector with the names of each group to be selected.
+#' @param na.rm logical. Should missing values of the grouping variable be removed? Default is `FALSE`.
+#' @param show_zero logical. Should the levels of the grouping variable that don't have data be shown? Default is `FALSE`.
 #' @param round_digits Number of digits to round percentages. It is 2 by default.
 #' @param trim_trailing_zeros Logical value. If `TRUE`, allows trailing zeros after the decimal to be trimmed (default is `FALSE`).
-#' @param just Justification for the text: left, center or right. Default is center.
-#' @param text_color Color of the text. It is black by default.
+#' @param just Justification for the text: `"left"`, `"center"` or `"right"`. Default is `"center"`.
+#' @param text_color Color of the text. It is `"black"` by default.
 #' @param text_fs Font size of the text. It is 8 by default.
-#' @param text_fface Font face of the text. It is 1 by default. See the `fontface` parameter for \code{\link{gpar}}.
-#' @param text_ffamily Changes the font family of the text. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}.
+#' @param text_fface Font face of the text. It is 1 by default. See the `fontface` parameter for [gpar].
+#' @param text_ffamily Changes the font family of the text. Default is `NA`. See the `fontfamily` parameter for [gpar].
 #' @param text_padding Changes the text padding inside the box. Default is 1. This number has to be greater than 0.
-#' @param bg_fill Box background color. It is white by default.
-#' @param border_color Box border color. It is black by default.
-#' @param width Width of the box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.
-#' @param height Height of the box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.
-#' @param title Add a title box to the split. Default is NULL. It can only be used when there are only two resulting boxes after the split.
-#' @param text_color_title Color of the title text. It is black by default.
+#' @param bg_fill Box background color. It is `"white"` by default.
+#' @param border_color Box border color. It is `"black"` by default.
+#' @param width Width of the box. If `NA`, it automatically adjusts to the content (default). Must be an object of class [unit] or a number between 0 and 1.
+#' @param height Height of the box. If `NA`, it automatically adjusts to the content (default). Must be an object of class [unit] or a number between 0 and 1.
+#' @param title Add a title box to the split. Default is `NULL`. It can only be used when there are only two resulting boxes after the split.
+#' @param text_color_title Color of the title text. It is `"black"` by default.
 #' @param text_fs_title Font size of the title text. It is 8 by default.
-#' @param text_fface_title Font face of the title text. It is 1 by default. See the `fontface` parameter for \code{\link{gpar}}.
-#' @param text_ffamily_title Changes the font family of the title text. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}.
+#' @param text_fface_title Font face of the title text. It is 1 by default. See the `fontface` parameter for [gpar].
+#' @param text_ffamily_title Changes the font family of the title text. Default is `NA`. See the `fontfamily` parameter for [gpar].
 #' @param text_padding_title Changes the title text padding inside the box. Default is 1. This number has to be greater than 0.
-#' @param bg_fill_title Title box background color. It is white by default.
-#' @param border_color_title Title box border color. It is black by default.
-#' @param width_title Width of the title box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.
-#' @param height_title Height of the title box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.
-#' @param offset Amount of space to add to the distance between boxes (in the x coordinate). If positive, this distance will be larger. If negative, it will be smaller. This number has to be at least between 0 and 1 (plot limits) and the resulting x coordinate cannot exceed these plot limits. The default is NULL (no offset).
+#' @param bg_fill_title Title box background color. It is `"white"` by default.
+#' @param border_color_title Title box border color. It is `"black"` by default.
+#' @param width_title Width of the title box. If `NA`, it automatically adjusts to the content (default). Must be an object of class [unit] or a number between 0 and 1.
+#' @param height_title Height of the title box. If `NA`, it automatically adjusts to the content (default). Must be an object of class [unit] or a number between 0 and 1.
+#' @param offset Amount of space to add to the distance between boxes (in the x coordinate). If positive, this distance will be larger. If negative, it will be smaller. This number has to be at least between 0 and 1 (plot limits) and the resulting x coordinate cannot exceed these plot limits. The default is `NULL` (no offset).
 #' @return List with the dataset grouped by the splitting variable and the flowchart parameters with the resulting split.
 #'
 #' @examples

--- a/R/fc_stack.R
+++ b/R/fc_stack.R
@@ -2,7 +2,7 @@
 #' @description This function allows to combine vertically two different flowcharts.
 #'
 #' @param fcs list with all the flowcharts that we want to merge
-#' @param unite logical value if the boxes have to be united or not. Default is FALSE.
+#' @param unite logical value if the boxes have to be united or not. Default is `FALSE`.
 #' @return List containing a list with the datasets belonging to each flowchart and the flowchart parameters combining all the flowcharts.
 #'
 #' @examples

--- a/R/fc_theme.R
+++ b/R/fc_theme.R
@@ -5,35 +5,35 @@
 #' @param text_pattern Text pattern for all the boxes, except the initial and exclusion ones.
 #' @param text_pattern_init Text pattern for the initial box.
 #' @param text_pattern_exc Text pattern for the exclusion box.
-#' @param just Justification for the text: left, center or right.
-#' @param text_color Color of the text. See the `col` parameter for \code{\link{gpar}}.
-#' @param text_fs Font size of the text. See the `fontsize` parameter for \code{\link{gpar}}.
-#' @param text_fface Font face of the text. See the `fontface` parameter for \code{\link{gpar}}.
-#' @param text_ffamily Changes the font family of the text. See the `fontfamily` parameter for \code{\link{gpar}}.
+#' @param just Justification for the text: `"left"`, `"center"` or `"right"`.
+#' @param text_color Color of the text. See the `col` parameter for [gpar].
+#' @param text_fs Font size of the text. See the `fontsize` parameter for [gpar].
+#' @param text_fface Font face of the text. See the `fontface` parameter for [gpar].
+#' @param text_ffamily Changes the font family of the text. See the `fontfamily` parameter for [gpar].
 #' @param text_padding Changes the text padding inside the box. This number has to be greater than 0.
-#' @param bg_fill Box background color. See the `fill` parameter for \code{\link{gpar}}.
-#' @param border_color Box border color. See the `col` parameter for \code{\link{gpar}}.
-#' @param width Width of the box. Must be an object of class \code{\link{unit}} or a number between 0 and 1.
-#' @param height Height of the box. Must be an object of class \code{\link{unit}} or a number between 0 and 1.
-#' @param just_exc Justification for the text of the exclude box: left, center or right.
+#' @param bg_fill Box background color. See the `fill` parameter for [gpar].
+#' @param border_color Box border color. See the `col` parameter for [gpar].
+#' @param width Width of the box. Must be an object of class [unit] or a number between 0 and 1.
+#' @param height Height of the box. Must be an object of class [unit] or a number between 0 and 1.
+#' @param just_exc Justification for the text of the exclude box: `"left"`, `"center"` or `"right"`.
 #' @param text_color_exc Color of the text of the exclude box. See `text_color`.
 #' @param text_fs_exc Font size of the text of the exclude box. See `text_fs`.
-#' @param text_fface_exc Font face of the text of the exclude box. See the `fontface` parameter for \code{\link{gpar}}. See `text_fface`.
-#' @param text_ffamily_exc Changes the font family of the text of the exclude box. See the `fontfamily` parameter for \code{\link{gpar}}. See `text_ffamily`.
+#' @param text_fface_exc Font face of the text of the exclude box. See the `fontface` parameter for [gpar]. See `text_fface`.
+#' @param text_ffamily_exc Changes the font family of the text of the exclude box. See the `fontfamily` parameter for [gpar]. See `text_ffamily`.
 #' @param text_padding_exc Changes the text padding inside the exclude box. This number has to be greater than 0.
 #' @param bg_fill_exc Exclude box background color. See `bg_fill`.
 #' @param border_color_exc Box background color of the exclude box. See `border_color`.
-#' @param width_exc Width of the exclude box. Must be an object of class \code{\link{unit}} or a number between 0 and 1.
-#' @param height_exc Height of the box. Must be an object of class \code{\link{unit}} or a number between 0 and 1.
+#' @param width_exc Width of the exclude box. Must be an object of class [unit] or a number between 0 and 1.
+#' @param height_exc Height of the box. Must be an object of class [unit] or a number between 0 and 1.
 #' @param text_color_title Color of the title text.
 #' @param text_fs_title Font size of the title text.
-#' @param text_fface_title Font face of the title text. See the `fontface` parameter for \code{\link{gpar}}.
-#' @param text_ffamily_title Changes the font family of the title text. See the `fontfamily` parameter for \code{\link{gpar}}.
+#' @param text_fface_title Font face of the title text. See the `fontface` parameter for [gpar].
+#' @param text_ffamily_title Changes the font family of the title text. See the `fontfamily` parameter for [gpar].
 #' @param text_padding_title Changes the title text padding inside the box. This number has to be greater than 0.
 #' @param bg_fill_title Title box background color.
 #' @param border_color_title Title box border color.
-#' @param width_title Width of the title box. Must be an object of class \code{\link{unit}} or a number between 0 and 1.
-#' @param height_title Height of the title box. Must be an object of class \code{\link{unit}} or a number between 0 and 1.
+#' @param width_title Width of the title box. Must be an object of class [unit] or a number between 0 and 1.
+#' @param height_title Height of the title box. Must be an object of class [unit] or a number between 0 and 1.
 #'
 #' @return List with the dataset and the flowchart parameters with their modifications.
 #'

--- a/R/fc_view.R
+++ b/R/fc_view.R
@@ -2,7 +2,7 @@
 #' @description This function allows you to return either the data stored in `$data` or the flowchart information stored in `$fc`.
 #'
 #' @param object fc object that we want to access.
-#' @param what Choose "data" to return the data associated to the flowchart stored in `$data` or "fc" to return the flowchart information stored in `$fc`.
+#' @param what Choose `"data"` to return the data associated to the flowchart stored in `$data` or `"fc"` to return the flowchart information stored in `$fc`.
 #' @return Returns a tibble. Either `$data` or `$fc`.
 #'
 #' @examples

--- a/man/as_fc.Rd
+++ b/man/as_fc.Rd
@@ -25,33 +25,33 @@ as_fc(
 \arguments{
 \item{.data}{Data frame to be initialised as a flowchart.}
 
-\item{N}{Number of rows of the study in case `.data` is NULL.}
+\item{N}{Number of rows of the study in case \code{.data} is \code{NULL}.}
 
 \item{label}{Character or expression with the text that will be shown in the box.}
 
-\item{text_pattern}{Character or expression defining the structure that will have the text in each of the boxes. It recognizes label, n, N and perc within brackets. For default it is "\{label\}\\n \{n\}". If text_pattern or label is an expression, the label is always placed at the beginning of the pattern, followed by a line break where the structure specified by text_pattern is placed.}
+\item{text_pattern}{Character or expression defining the structure that will have the text in each of the boxes. It recognizes \code{label}, \code{n}, \code{N} and \code{perc} within brackets. For default it is \code{"{label}\\n {n}"}. If \code{text_pattern} or \code{label} is an expression, the \code{label} is always placed at the beginning of the pattern, followed by a line break where the structure specified by \code{text_pattern} is placed.}
 
 \item{just}{Justification for the text: left, center or right. Default is center.}
 
-\item{text_color}{Color of the text. It is black by default. See the `col` parameter for \code{\link{gpar}}.}
+\item{text_color}{Color of the text. It is \code{"black"} by default. See the \code{col} parameter for \link{gpar}.}
 
-\item{text_fs}{Font size of the text. It is 8 by default. See the `fontsize` parameter for \code{\link{gpar}}.}
+\item{text_fs}{Font size of the text. It is 8 by default. See the \code{fontsize} parameter for \link{gpar}.}
 
-\item{text_fface}{Font face of the text. It is 1 by default. See the `fontface` parameter for \code{\link{gpar}}.}
+\item{text_fface}{Font face of the text. It is 1 by default. See the \code{fontface} parameter for \link{gpar}.}
 
-\item{text_ffamily}{Changes the font family of the text. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}.}
+\item{text_ffamily}{Changes the font family of the text. Default is \code{NA}. See the \code{fontfamily} parameter for \link{gpar}.}
 
 \item{text_padding}{Changes the text padding inside the box. Default is 1. This number has to be greater than 0.}
 
-\item{bg_fill}{Box background color. It is white by default. See the `fill` parameter for \code{\link{gpar}}.}
+\item{bg_fill}{Box background color. It is white by default. See the \code{fill} parameter for \link{gpar}.}
 
-\item{border_color}{Box border color. It is black by default. See the `col` parameter for \code{\link{gpar}}.}
+\item{border_color}{Box border color. It is \code{"black"} by default. See the \code{col} parameter for \link{gpar}.}
 
-\item{width}{Width of the box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{width}{Width of the box. If \code{NA}, it automatically adjusts to the content (default). Must be an object of class \link{unit} or a number between 0 and 1.}
 
-\item{height}{Height of the box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{height}{Height of the box. If \code{NA}, it automatically adjusts to the content (default). Must be an object of class \link{unit} or a number between 0 and 1.}
 
-\item{hide}{Logical value to hide the initial box or not. Default is FALSE. hide = TRUE can only be combined with fc_split().}
+\item{hide}{Logical value to hide the initial box or not. Default is FALSE. hide = TRUE can only be combined with \code{\link[=fc_split]{fc_split()}}.}
 }
 \value{
 List with the dataset and the initialized flowchart parameters.

--- a/man/fc_draw.Rd
+++ b/man/fc_draw.Rd
@@ -25,17 +25,17 @@ fc_draw(
 \arguments{
 \item{object}{fc object that we want to draw.}
 
-\item{big.mark}{character. Used to specify the thousands separator for patient count values. Defaults is no separator (`""`); if not empty used as mark between every 3 digits (ex: `big.mark = ","` results in `1,000` instead of `1000`).}
+\item{big.mark}{character. Used to specify the thousands separator for patient count values. Defaults is no separator (\code{""}); if not empty used as mark between every 3 digits (ex: \code{big.mark = ","} results in \verb{1,000} instead of \code{1000}).}
 
-\item{box_corners}{Indicator of whether to draw boxes with round (`"round"`) vs non-round (`"sharp"`) corners. Default is `"round"`.}
+\item{box_corners}{Indicator of whether to draw boxes with round (\code{"round"}) vs non-round (\code{"sharp"}) corners. Default is \code{"round"}.}
 
-\item{arrow_angle}{The angle of the arrow head in degrees, as in `arrow`.}
+\item{arrow_angle}{The angle of the arrow head in degrees, as in \code{arrow}.}
 
-\item{arrow_length}{A unit specifying the length of the arrow head (from tip to base), as in `arrow`.}
+\item{arrow_length}{A unit specifying the length of the arrow head (from tip to base), as in \code{arrow}.}
 
-\item{arrow_ends}{One of "last", "first", or "both", indicating which ends of the line to draw arrow heads, as in `arrow`.}
+\item{arrow_ends}{One of "last", "first", or "both", indicating which ends of the line to draw arrow heads, as in \code{arrow}.}
 
-\item{arrow_type}{One of "open" or "closed" indicating whether the arrow head should be a closed triangle, as in `arrow`.}
+\item{arrow_type}{One of "open" or "closed" indicating whether the arrow head should be a closed triangle, as in \code{arrow}.}
 
 \item{title}{The title of the flowchart. Default is NULL (no title).}
 
@@ -43,15 +43,15 @@ fc_draw(
 
 \item{title_y}{y coordinate for the title. Default is 0.9.}
 
-\item{title_color}{Color of the title. It is black by default. See the `col` parameter for \code{\link{gpar}}.}
+\item{title_color}{Color of the title. It is black by default. See the \code{col} parameter for \code{\link{gpar}}.}
 
-\item{title_fs}{Font size of the title. It is 15 by default. See the `fontsize` parameter for \code{\link{gpar}}.}
+\item{title_fs}{Font size of the title. It is 15 by default. See the \code{fontsize} parameter for \code{\link{gpar}}.}
 
-\item{title_fface}{Font face of the title. It is 2 by default. See the `fontface` parameter for \code{\link{gpar}}.}
+\item{title_fface}{Font face of the title. It is 2 by default. See the \code{fontface} parameter for \code{\link{gpar}}.}
 
-\item{title_ffamily}{Changes the font family of the title. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}.}
+\item{title_ffamily}{Changes the font family of the title. Default is NA. See the \code{fontfamily} parameter for \code{\link{gpar}}.}
 
-\item{canvas_bg}{Background color for the entire canvas (the area behind the flowchart boxes). Default is `"white"`. Set to `"transparent"` or `NULL` for a transparent background; `"transparent"` background will only be noticeable when exporting drawn flowcharts via `fc_export()` and is compatible with all `fc_export()` formats except `"jpeg"` and `"bmp"`.}
+\item{canvas_bg}{Background color for the entire canvas (the area behind the flowchart boxes). Default is \code{"white"}. Set to \code{"transparent"} or \code{NULL} for a transparent background; \code{"transparent"} background will only be noticeable when exporting drawn flowcharts via \code{fc_export()} and is compatible with all \code{fc_export()} formats except \code{"jpeg"} and \code{"bmp"}.}
 }
 \value{
 Invisibly returns the same object that has been given to the function, with the given arguments to draw the flowchart stored in the attributes.

--- a/man/fc_draw.Rd
+++ b/man/fc_draw.Rd
@@ -12,6 +12,10 @@ fc_draw(
   arrow_length = grid::unit(0.1, "inches"),
   arrow_ends = "last",
   arrow_type = "closed",
+  arrow_color = "black",
+  arrow_lwd = 1,
+  arrow_lineend = "round",
+  arrow_linejoin = "round",
   title = NULL,
   title_x = 0.5,
   title_y = 0.9,
@@ -33,25 +37,33 @@ fc_draw(
 
 \item{arrow_length}{A unit specifying the length of the arrow head (from tip to base), as in \code{arrow}.}
 
-\item{arrow_ends}{One of "last", "first", or "both", indicating which ends of the line to draw arrow heads, as in \code{arrow}.}
+\item{arrow_ends}{One of \code{"last"}, \code{"first"}, or \code{"both"}, indicating which ends of the line to draw arrow heads, as in \link{arrow}.}
 
-\item{arrow_type}{One of "open" or "closed" indicating whether the arrow head should be a closed triangle, as in \code{arrow}.}
+\item{arrow_type}{One of \code{"open"} or \code{"closed"} indicating whether the arrow head should be a closed triangle, as in \link{arrow}.}
 
-\item{title}{The title of the flowchart. Default is NULL (no title).}
+\item{arrow_color}{Color of the arrows. Default is \code{"black"}. See the \code{col} parameter for \link{gpar}.}
+
+\item{arrow_lwd}{Line width of the arrows. Default is 1. See the \code{lwd} parameter for \link{gpar}.}
+
+\item{arrow_lineend}{Line end style for arrows. One of \code{"round"}, \code{"butt"}, or \code{"square"}. Default is \code{"round"}. See the \code{lineend} parameter for \link{gpar}.}
+
+\item{arrow_linejoin}{Line join style for arrow heads (i.e., shape of arrow head corners). One of \code{"round"}, \code{"mitre"}, or \code{"bevel"}. Default is \code{"round"}. See the \code{linejoin} parameter for \link{gpar}.}
+
+\item{title}{The title of the flowchart. Default is \code{NULL} (no title).}
 
 \item{title_x}{x coordinate for the title. Default is 0.5.}
 
 \item{title_y}{y coordinate for the title. Default is 0.9.}
 
-\item{title_color}{Color of the title. It is black by default. See the \code{col} parameter for \code{\link{gpar}}.}
+\item{title_color}{Color of the title. It is \code{"black"} by default. See the \code{col} parameter for \link{gpar}.}
 
-\item{title_fs}{Font size of the title. It is 15 by default. See the \code{fontsize} parameter for \code{\link{gpar}}.}
+\item{title_fs}{Font size of the title. It is 15 by default. See the \code{fontsize} parameter for \link{gpar}.}
 
-\item{title_fface}{Font face of the title. It is 2 by default. See the \code{fontface} parameter for \code{\link{gpar}}.}
+\item{title_fface}{Font face of the title. It is 2 by default. See the \code{fontface} parameter for \link{gpar}.}
 
-\item{title_ffamily}{Changes the font family of the title. Default is NA. See the \code{fontfamily} parameter for \code{\link{gpar}}.}
+\item{title_ffamily}{Changes the font family of the title. Default is \code{NA}. See the \code{fontfamily} parameter for \link{gpar}.}
 
-\item{canvas_bg}{Background color for the entire canvas (the area behind the flowchart boxes). Default is \code{"white"}. Set to \code{"transparent"} or \code{NULL} for a transparent background; \code{"transparent"} background will only be noticeable when exporting drawn flowcharts via \code{fc_export()} and is compatible with all \code{fc_export()} formats except \code{"jpeg"} and \code{"bmp"}.}
+\item{canvas_bg}{Background color for the entire canvas (the area behind the flowchart boxes). Default is \code{"white"}. Set to \code{"transparent"} or \code{NULL} for a transparent background; \code{"transparent"} background will only be noticeable when exporting drawn flowcharts via \code{\link[=fc_export]{fc_export()}} and is compatible with all \code{\link[=fc_export]{fc_export()}} formats except \code{"jpeg"} and \code{"bmp"}.}
 }
 \value{
 Invisibly returns the same object that has been given to the function, with the given arguments to draw the flowchart stored in the attributes.

--- a/man/fc_export.Rd
+++ b/man/fc_export.Rd
@@ -23,27 +23,27 @@ fc_export(
 
 \item{path}{Path of the directory to save plot to: path and filename are combined to create the fully qualified file name. Defaults to the working directory.}
 
-\item{format}{Name of the graphic device. One of 'png', 'jpeg', 'tiff', 'bmp', 'svg', or 'pdf'. If \code{NULL} (default), the format is guessed based on the filename extension.}
+\item{format}{Name of the graphic device. One of \code{"png"}, \code{"jpeg"}, \code{"tiff"}, \code{"bmp"}, \code{"svg"}, or \code{"pdf"}. If \code{NULL} (default), the format is guessed based on the filename extension.}
 
 \item{width, height}{Plot size in units expressed by the \code{units} argument. Default is 600px for bitmap formats and 6 inches for vector formats.}
 
-\item{units}{One of the following units in which the width and height arguments are expressed: "in", "cm", "mm" for vector formats and "in", "cm", "mm" or "px" for bitmap formats. If left \code{NULL} (default), the function will automatically use "px" for bitmap formats and "in" for vector formats.}
+\item{units}{One of the following units in which the width and height arguments are expressed: \code{"in"}, \code{"cm"}, \code{"mm"} for vector formats and \code{"in"}, \code{"cm"}, \code{"mm"} or \code{"px"} for bitmap formats. If left \code{NULL} (default), the function will automatically use \code{"px"} for bitmap formats and \code{"in"} for vector formats.}
 
 \item{res}{The nominal resolution in ppi which will be recorded in the bitmap file, if a positive integer. Also used for units other than the default, and to convert points to pixels. Default is 100 if exporting in bitmap format. This argument is unused if exporting to a vector format.}
 
-\item{...}{Arguments to be passed to the device function used to save the flowchart. The available parameters will differ depending on the format (e.g., \code{\link{png}}).}
+\item{...}{Arguments to be passed to the device function used to save the flowchart. The available parameters will differ depending on the format (e.g., \link{png}).}
 }
 \value{
 Invisibly returns the same object that has been given to the function.
 }
 \description{
-This function allows you to export the drawn flowchart to the most popular graphic formats, including bitmap formats (png, jpeg, tiff, bmp) and vector formats (svg, pdf). For bitmap formats, it uses the \code{ragg} package devices when available for higher performance and higher quality output than standard raster devices provide by \code{grDevices}.
+This function allows you to export the drawn flowchart to the most popular graphic formats, including bitmap formats (png, jpeg, tiff, bmp) and vector formats (svg, pdf). For bitmap formats, it uses the \link{ragg} package devices when available for higher performance and higher quality output than standard raster devices provide by \link{grDevices}.
 }
 \details{
 \itemize{
-\item \strong{Vector Formats ('svg', 'pdf'):} These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies \code{units} other than inches ("mm" or "cm"), the function will convert the dimensions to inches using standard conversion formulas.
-\item \strong{Bitmap Formats ('png', 'jpeg', 'tiff', 'bmp'):} For these formats (with the exception of 'bmp'), the function uses the \code{ragg} package devices when available, providing higher performance and higher quality output. The default units for width and height are pixels.
-\item \strong{Suggested Dependencies:} For superior performance and quality bitmap outputs, it is recommended to install the \code{ragg} package. For exporting to 'pdf' format with enhanced features, the Cairo graphics library will be used if it is available.
+\item \strong{Vector Formats (\code{'svg'}, \code{'pdf'}):} These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies \code{units} other than inches (\code{"mm"} or\code{ "cm"}), the function will convert the dimensions to inches using standard conversion formulas.
+\item \strong{Bitmap Formats (\code{'png'}, \code{'jpeg'}, \code{'tiff'}, \code{'bmp'}):} For these formats (with the exception of \code{"bmp"}), the function uses the \link{ragg} package devices when available, providing higher performance and higher quality output. The default \code{units} for \code{width} and \code{height} are pixels.
+\item \strong{Suggested Dependencies:} For superior performance and quality bitmap outputs, it is recommended to install the \link{ragg} package. For exporting to \code{"pdf"} format with enhanced features, the Cairo graphics library will be used if it is available.
 }
 }
 \examples{

--- a/man/fc_export.Rd
+++ b/man/fc_export.Rd
@@ -23,11 +23,11 @@ fc_export(
 
 \item{path}{Path of the directory to save plot to: path and filename are combined to create the fully qualified file name. Defaults to the working directory.}
 
-\item{format}{Name of the graphic device. One of 'png', 'jpeg', 'tiff', 'bmp', 'svg', or 'pdf'. If `NULL` (default), the format is guessed based on the filename extension.}
+\item{format}{Name of the graphic device. One of 'png', 'jpeg', 'tiff', 'bmp', 'svg', or 'pdf'. If \code{NULL} (default), the format is guessed based on the filename extension.}
 
-\item{width, height}{Plot size in units expressed by the `units` argument. Default is 600px for bitmap formats and 6 inches for vector formats.}
+\item{width, height}{Plot size in units expressed by the \code{units} argument. Default is 600px for bitmap formats and 6 inches for vector formats.}
 
-\item{units}{One of the following units in which the width and height arguments are expressed: "in", "cm", "mm" for vector formats and "in", "cm", "mm" or "px" for bitmap formats. If left `NULL` (default), the function will automatically use "px" for bitmap formats and "in" for vector formats.}
+\item{units}{One of the following units in which the width and height arguments are expressed: "in", "cm", "mm" for vector formats and "in", "cm", "mm" or "px" for bitmap formats. If left \code{NULL} (default), the function will automatically use "px" for bitmap formats and "in" for vector formats.}
 
 \item{res}{The nominal resolution in ppi which will be recorded in the bitmap file, if a positive integer. Also used for units other than the default, and to convert points to pixels. Default is 100 if exporting in bitmap format. This argument is unused if exporting to a vector format.}
 
@@ -37,12 +37,14 @@ fc_export(
 Invisibly returns the same object that has been given to the function.
 }
 \description{
-This function allows you to export the drawn flowchart to the most popular graphic formats, including bitmap formats (png, jpeg, tiff, bmp) and vector formats (svg, pdf). For bitmap formats, it uses the `ragg` package devices when available for higher performance and higher quality output than standard raster devices provide by `grDevices`.
+This function allows you to export the drawn flowchart to the most popular graphic formats, including bitmap formats (png, jpeg, tiff, bmp) and vector formats (svg, pdf). For bitmap formats, it uses the \code{ragg} package devices when available for higher performance and higher quality output than standard raster devices provide by \code{grDevices}.
 }
 \details{
-- **Vector Formats ('svg', 'pdf'):** These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies `units` other than inches ("mm" or "cm"), the function will convert the dimensions to inches using standard conversion formulas.
-- **Bitmap Formats ('png', 'jpeg', 'tiff', 'bmp'):** For these formats (with the exception of 'bmp'), the function uses the `ragg` package devices when available, providing higher performance and higher quality output. The default units for width and height are pixels.
-- **Suggested Dependencies:** For superior performance and quality bitmap outputs, it is recommended to install the `ragg` package. For exporting to 'pdf' format with enhanced features, the Cairo graphics library will be used if it is available.
+\itemize{
+\item \strong{Vector Formats ('svg', 'pdf'):} These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies \code{units} other than inches ("mm" or "cm"), the function will convert the dimensions to inches using standard conversion formulas.
+\item \strong{Bitmap Formats ('png', 'jpeg', 'tiff', 'bmp'):} For these formats (with the exception of 'bmp'), the function uses the \code{ragg} package devices when available, providing higher performance and higher quality output. The default units for width and height are pixels.
+\item \strong{Suggested Dependencies:} For superior performance and quality bitmap outputs, it is recommended to install the \code{ragg} package. For exporting to 'pdf' format with enhanced features, the Cairo graphics library will be used if it is available.
+}
 }
 \examples{
 \dontrun{

--- a/man/fc_export.Rd
+++ b/man/fc_export.Rd
@@ -37,13 +37,13 @@ fc_export(
 Invisibly returns the same object that has been given to the function.
 }
 \description{
-This function allows you to export the drawn flowchart to the most popular graphic formats, including bitmap formats (png, jpeg, tiff, bmp) and vector formats (svg, pdf). For bitmap formats, it uses the \link{ragg} package devices when available for higher performance and higher quality output than standard raster devices provide by \link{grDevices}.
+This function allows you to export the drawn flowchart to the most popular graphic formats, including bitmap formats (png, jpeg, tiff, bmp) and vector formats (svg, pdf). For bitmap formats, it uses the \href{https://ragg.r-lib.org/}{ragg} package devices when available for higher performance and higher quality output than standard raster devices provide by \link{grDevices}.
 }
 \details{
 \itemize{
 \item \strong{Vector Formats (\code{'svg'}, \code{'pdf'}):} These formats are ideal for graphics that need to be scaled without loss of quality. The default units for width and height are inches. If user specifies \code{units} other than inches (\code{"mm"} or\code{ "cm"}), the function will convert the dimensions to inches using standard conversion formulas.
-\item \strong{Bitmap Formats (\code{'png'}, \code{'jpeg'}, \code{'tiff'}, \code{'bmp'}):} For these formats (with the exception of \code{"bmp"}), the function uses the \link{ragg} package devices when available, providing higher performance and higher quality output. The default \code{units} for \code{width} and \code{height} are pixels.
-\item \strong{Suggested Dependencies:} For superior performance and quality bitmap outputs, it is recommended to install the \link{ragg} package. For exporting to \code{"pdf"} format with enhanced features, the Cairo graphics library will be used if it is available.
+\item \strong{Bitmap Formats (\code{'png'}, \code{'jpeg'}, \code{'tiff'}, \code{'bmp'}):} For these formats (with the exception of \code{"bmp"}), the function uses the \href{https://ragg.r-lib.org/}{ragg} package devices when available, providing higher performance and higher quality output. The default \code{units} for \code{width} and \code{height} are pixels.
+\item \strong{Suggested Dependencies:} For superior performance and quality bitmap outputs, it is recommended to install the \href{https://ragg.r-lib.org/}{ragg} package. For exporting to \code{"pdf"} format with enhanced features, the Cairo graphics library will be used if it is available.
 }
 }
 \examples{

--- a/man/fc_filter.Rd
+++ b/man/fc_filter.Rd
@@ -46,69 +46,69 @@ fc_filter(
 
 \item{filter}{Expression that returns a logical value and are defined in terms of the variables in the data frame. The data base will be filtered by this expression, and it will create a box showing the number of rows satisfying this condition.}
 
-\item{N}{Number of rows after the filter in case `filter` is NULL.}
+\item{N}{Number of rows after the filter in case \code{filter} is \code{NULL}.}
 
 \item{label}{Character or expression that will be the title of the box. By default it will be the evaluated condition.}
 
-\item{text_pattern}{Character or expression defining the structure that will have the text in each of the boxes. It recognizes label, n, N and perc within brackets. For default it is "\{label\}\\n \{n\} (\{perc\}\%)". If text_pattern or label is an expression, the label is always placed at the beginning of the pattern, followed by a line break where the structure specified by text_pattern is placed.}
+\item{text_pattern}{Character or expression defining the structure that will have the text in each of the boxes. It recognizes \code{label}, \code{n}, \code{N} and \code{perc} within brackets. For default it is \code{"{label}\\n {n} ({perc}\%)"}. If \code{text_pattern} or \code{label} is an expression, the \code{label} is always placed at the beginning of the pattern, followed by a line break where the structure specified by \code{text_pattern} is placed.}
 
-\item{perc_total}{logical. Should percentages be calculated using the total number of rows at the beginning of the flowchart? Default is FALSE, meaning that they will be calculated using the number at the parent leaf.}
+\item{perc_total}{logical. Should percentages be calculated using the total number of rows at the beginning of the flowchart? Default is \code{FALSE}, meaning that they will be calculated using the number at the parent leaf.}
 
-\item{show_exc}{Logical value. If TRUE a box showing the number of excluded rows will be added to the flow chart.}
+\item{show_exc}{Logical value. If \code{TRUE} a box showing the number of excluded rows will be added to the flow chart.}
 
-\item{direction_exc}{One of "left" or "right" indicating if the exclusion box goes into the left direction or in the right direction. By default is "right".}
+\item{direction_exc}{One of \code{"left"} or \code{"right"} indicating if the exclusion box goes into the left direction or in the right direction. By default is \code{"right"}.}
 
 \item{label_exc}{Character or expression that will be the title of the added box showing the excluded patients. By default it will show "Excluded".}
 
-\item{text_pattern_exc}{Character or expression defining the structure that will have the text in the exclude box. It recognizes label, n, N and perc within brackets. For default it is "\{label\}\\n \{n\} (\{perc\}\%)". If text_pattern or label is an expression, the label is always placed at the beginning of the pattern, followed by a line break where the structure specified by text_pattern_exc is placed.}
+\item{text_pattern_exc}{Character or expression defining the structure that will have the text in the exclude box. It recognizes \code{label}, \code{n}, \code{N} and \code{perc} within brackets. For default it is \code{"{label}\\n {n} ({perc}\%)"}. If text_pattern or label is an expression, the label is always placed at the beginning of the pattern, followed by a line break where the structure specified by \code{text_pattern_exc} is placed.}
 
-\item{sel_group}{Select the group in which to perform the filter. The default is NULL. Can only be used if the flowchart has previously been split. If the flowchart has more than one group, it can either be given the full name as it is stored in the `$fc` component (separated by '\\'), or it can be given as a vector with the names of each group to be selected.}
+\item{sel_group}{Select the group in which to perform the filter. The default is \code{NULL}. Can only be used if the flowchart has previously been split. If the flowchart has more than one group, it can either be given the full name as it is stored in the \verb{$fc} component (separated by '\\'), or it can be given as a vector with the names of each group to be selected.}
 
 \item{round_digits}{Number of digits to round percentages. It is 2 by default.}
 
-\item{trim_trailing_zeros}{Logical value. If `TRUE`, allows trailing zeros after the decimal to be trimmed (default is `FALSE`).}
+\item{trim_trailing_zeros}{Logical value. If \code{TRUE}, allows trailing zeros after the decimal to be trimmed (default is \code{FALSE}).}
 
-\item{just}{Justification for the text: left, center or right. Default is center.}
+\item{just}{Justification for the text: \code{"left"}, \code{"center"} or \code{"right"}. Default is \code{"center"}.}
 
-\item{text_color}{Color of the text. It is black by default. See the `col` parameter for \code{\link{gpar}}.}
+\item{text_color}{Color of the text. It is \code{"black"} by default. See the \code{col} parameter for \link{gpar}.}
 
-\item{text_fs}{Font size of the text. It is 8 by default. See the `fontsize` parameter for \code{\link{gpar}}.}
+\item{text_fs}{Font size of the text. It is 8 by default. See the \code{fontsize} parameter for \link{gpar}.}
 
-\item{text_fface}{Font face of the text. It is 1 by default. See the `fontface` parameter for \code{\link{gpar}}.}
+\item{text_fface}{Font face of the text. It is 1 by default. See the \code{fontface} parameter for \link{gpar}.}
 
-\item{text_ffamily}{Changes the font family of the text. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}.}
+\item{text_ffamily}{Changes the font family of the text. Default is \code{NA}. See the \code{fontfamily} parameter for \link{gpar}.}
 
 \item{text_padding}{Changes the text padding inside the box. Default is 1. This number has to be greater than 0.}
 
-\item{bg_fill}{Box background color. It is white by default. See the `fill` parameter for \code{\link{gpar}}.}
+\item{bg_fill}{Box background color. It is \code{"white"} by default. See the \code{fill} parameter for \link{gpar}.}
 
-\item{border_color}{Box border color. It is black by default. See the `col` parameter for \code{\link{gpar}}.}
+\item{border_color}{Box border color. It is \code{"black"} by default. See the \code{col} parameter for \link{gpar}.}
 
-\item{width}{Width of the box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{width}{Width of the box. If \code{NA}, it automatically adjusts to the content (default). Must be an object of class \link{unit} or a number between 0 and 1.}
 
-\item{height}{Height of the box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{height}{Height of the box. If \code{NA}, it automatically adjusts to the content (default). Must be an object of class \link{unit} or a number between 0 and 1.}
 
-\item{just_exc}{Justification for the text of the exclude box: left, center or right. Default is center.}
+\item{just_exc}{Justification for the text of the exclude box: \code{"left"}, \code{"center"} or \code{"right"}. Default is \code{"center"}.}
 
-\item{text_color_exc}{Color of the text of the exclude box. It is black by default. See `text_color`.}
+\item{text_color_exc}{Color of the text of the exclude box. It is \code{"black"} by default. See \code{text_color}.}
 
-\item{text_fs_exc}{Font size of the text of the exclude box. It is 6 by default. See `text_fs`.}
+\item{text_fs_exc}{Font size of the text of the exclude box. It is 6 by default. See \code{text_fs}.}
 
-\item{text_fface_exc}{Font face of the text of the exclude box. It is 1 by default. See the `fontface` parameter for \code{\link{gpar}}. See `text_fface`.}
+\item{text_fface_exc}{Font face of the text of the exclude box. It is 1 by default. See the \code{fontface} parameter for \link{gpar}. See \code{text_fface}.}
 
-\item{text_ffamily_exc}{Changes the font family of the text of the exclude box. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}. See `text_ffamily`.}
+\item{text_ffamily_exc}{Changes the font family of the text of the exclude box. Default is \code{NA}. See the \code{fontfamily} parameter for \link{gpar}. See \code{text_ffamily}.}
 
 \item{text_padding_exc}{Changes the text padding inside the exclude box. Default is 1. This number has to be greater than 0.}
 
-\item{bg_fill_exc}{Exclude box background color. It is white by default. See `bg_fill`.}
+\item{bg_fill_exc}{Exclude box background color. It is \code{"white"} by default. See \code{bg_fill}.}
 
-\item{border_color_exc}{Box background color of the exclude box. It is black by default. See `border_color`.}
+\item{border_color_exc}{Box background color of the exclude box. It is \code{"black"} by default. See \code{border_color}.}
 
-\item{offset_exc}{Amount of space to add to the distance between the box and the excluded box (in the x coordinate). If positive, this distance will be larger. If negative, it will be smaller. This number has to be at least between 0 and 1 (plot limits) and the resulting x coordinate cannot exceed these plot limits. The default is NULL (no offset).}
+\item{offset_exc}{Amount of space to add to the distance between the box and the excluded box (in the x coordinate). If positive, this distance will be larger. If negative, it will be smaller. This number has to be at least between 0 and 1 (plot limits) and the resulting x coordinate cannot exceed these plot limits. The default is \code{NULL} (no offset).}
 
-\item{width_exc}{Width of the exclude box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{width_exc}{Width of the exclude box. If \code{NA}, it automatically adjusts to the content (default). Must be an object of class \link{unit} or a number between 0 and 1.}
 
-\item{height_exc}{Height of the box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{height_exc}{Height of the box. If \code{NA}, it automatically adjusts to the content (default). Must be an object of class \link{unit} or a number between 0 and 1.}
 }
 \value{
 List with the filtered dataset and the flowchart parameters with the resulting filtered box.

--- a/man/fc_modify.Rd
+++ b/man/fc_modify.Rd
@@ -9,7 +9,7 @@ fc_modify(object, fun, ...)
 \arguments{
 \item{object}{flowchart created as a fc object.}
 
-\item{fun}{A function or formula that will be applied to `.$fc`. If a _function_, it is used as is. If a _formula_, e.g. `fun = ~.x |> mutate(x = x + 0.2)`, it is converted to a function.}
+\item{fun}{A function or formula that will be applied to \code{.$fc}. If a \emph{function}, it is used as is. If a \emph{formula}, e.g. \code{fun = ~.x |> mutate(x = x + 0.2)}, it is converted to a function.}
 
 \item{...}{Additional arguments passed on to the mapped function.}
 }
@@ -17,7 +17,7 @@ fc_modify(object, fun, ...)
 List with the dataset and the modified flowchart parameters.
 }
 \description{
-This function allows to modify the `.$fc` tibble included in each fc object that contains all the parameters of the flowchart.
+This function allows to modify the \code{.$fc} tibble included in each fc object that contains all the parameters of the flowchart.
 }
 \examples{
 #Example: let's modify the excluded box

--- a/man/fc_split.Rd
+++ b/man/fc_split.Rd
@@ -44,65 +44,65 @@ fc_split(
 
 \item{var}{variable column of the database from which it will be splitted.}
 
-\item{N}{Number of rows after the split in case `var` is NULL.}
+\item{N}{Number of rows after the split in case \code{var} is \code{NULL}.}
 
 \item{label}{Vector of characters or vector of expressions with the label of each category in order. It has to have as many elements as categories has the column. By default, it will put the labels of the categories.}
 
-\item{text_pattern}{Character or expression defining the structure that will have the text in each of the boxes. It recognizes label, n, N and perc within brackets. For default it is "\{label\}\\n \{n\} (\{perc\}\%)". If text_pattern or label is an expression, the label is always placed at the beginning of the pattern, followed by a line break where the structure specified by text_pattern is placed.}
+\item{text_pattern}{Character or expression defining the structure that will have the text in each of the boxes. It recognizes \code{label}, \code{n}, \code{N} and \code{perc} within brackets. For default it is \code{"{label}\\n {n} ({perc}\%)"}. If \code{text_pattern} or \code{label} is an expression, the \code{label} is always placed at the beginning of the pattern, followed by a line break where the structure specified by \code{text_pattern} is placed.}
 
-\item{perc_total}{logical. Should percentages be calculated using the total number of rows at the beginning of the flowchart? Default is FALSE, meaning that they will be calculated using the number at the parent leaf.}
+\item{perc_total}{logical. Should percentages be calculated using the total number of rows at the beginning of the flowchart? Default is \code{FALSE}, meaning that they will be calculated using the number at the parent leaf.}
 
-\item{sel_group}{Select the group in which to perform the filter. The default is NULL. Can only be used if the flowchart has previously been split. If the flowchart has more than one group, it can either be given the full name as it is stored in the `$fc` component (separated by '\\'), or it can be given as a vector with the names of each group to be selected.}
+\item{sel_group}{Select the group in which to perform the filter. The default is \code{NULL}. Can only be used if the flowchart has previously been split. If the flowchart has more than one group, it can either be given the full name as it is stored in the \verb{$fc} component (separated by '\\'), or it can be given as a vector with the names of each group to be selected.}
 
-\item{na.rm}{logical. Should missing values of the grouping variable be removed? Default is FALSE.}
+\item{na.rm}{logical. Should missing values of the grouping variable be removed? Default is \code{FALSE}.}
 
-\item{show_zero}{logical. Should the levels of the grouping variable that don't have data be shown? Default is FALSE.}
+\item{show_zero}{logical. Should the levels of the grouping variable that don't have data be shown? Default is \code{FALSE}.}
 
 \item{round_digits}{Number of digits to round percentages. It is 2 by default.}
 
-\item{trim_trailing_zeros}{Logical value. If `TRUE`, allows trailing zeros after the decimal to be trimmed (default is `FALSE`).}
+\item{trim_trailing_zeros}{Logical value. If \code{TRUE}, allows trailing zeros after the decimal to be trimmed (default is \code{FALSE}).}
 
-\item{just}{Justification for the text: left, center or right. Default is center.}
+\item{just}{Justification for the text: \code{"left"}, \code{"center"} or \code{"right"}. Default is \code{"center"}.}
 
-\item{text_color}{Color of the text. It is black by default.}
+\item{text_color}{Color of the text. It is \code{"black"} by default.}
 
 \item{text_fs}{Font size of the text. It is 8 by default.}
 
-\item{text_fface}{Font face of the text. It is 1 by default. See the `fontface` parameter for \code{\link{gpar}}.}
+\item{text_fface}{Font face of the text. It is 1 by default. See the \code{fontface} parameter for \link{gpar}.}
 
-\item{text_ffamily}{Changes the font family of the text. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}.}
+\item{text_ffamily}{Changes the font family of the text. Default is \code{NA}. See the \code{fontfamily} parameter for \link{gpar}.}
 
 \item{text_padding}{Changes the text padding inside the box. Default is 1. This number has to be greater than 0.}
 
-\item{bg_fill}{Box background color. It is white by default.}
+\item{bg_fill}{Box background color. It is \code{"white"} by default.}
 
-\item{border_color}{Box border color. It is black by default.}
+\item{border_color}{Box border color. It is \code{"black"} by default.}
 
-\item{width}{Width of the box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{width}{Width of the box. If \code{NA}, it automatically adjusts to the content (default). Must be an object of class \link{unit} or a number between 0 and 1.}
 
-\item{height}{Height of the box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{height}{Height of the box. If \code{NA}, it automatically adjusts to the content (default). Must be an object of class \link{unit} or a number between 0 and 1.}
 
-\item{title}{Add a title box to the split. Default is NULL. It can only be used when there are only two resulting boxes after the split.}
+\item{title}{Add a title box to the split. Default is \code{NULL}. It can only be used when there are only two resulting boxes after the split.}
 
-\item{text_color_title}{Color of the title text. It is black by default.}
+\item{text_color_title}{Color of the title text. It is \code{"black"} by default.}
 
 \item{text_fs_title}{Font size of the title text. It is 8 by default.}
 
-\item{text_fface_title}{Font face of the title text. It is 1 by default. See the `fontface` parameter for \code{\link{gpar}}.}
+\item{text_fface_title}{Font face of the title text. It is 1 by default. See the \code{fontface} parameter for \link{gpar}.}
 
-\item{text_ffamily_title}{Changes the font family of the title text. Default is NA. See the `fontfamily` parameter for \code{\link{gpar}}.}
+\item{text_ffamily_title}{Changes the font family of the title text. Default is \code{NA}. See the \code{fontfamily} parameter for \link{gpar}.}
 
 \item{text_padding_title}{Changes the title text padding inside the box. Default is 1. This number has to be greater than 0.}
 
-\item{bg_fill_title}{Title box background color. It is white by default.}
+\item{bg_fill_title}{Title box background color. It is \code{"white"} by default.}
 
-\item{border_color_title}{Title box border color. It is black by default.}
+\item{border_color_title}{Title box border color. It is \code{"black"} by default.}
 
-\item{width_title}{Width of the title box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{width_title}{Width of the title box. If \code{NA}, it automatically adjusts to the content (default). Must be an object of class \link{unit} or a number between 0 and 1.}
 
-\item{height_title}{Height of the title box. If NA, it automatically adjusts to the content (default). Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{height_title}{Height of the title box. If \code{NA}, it automatically adjusts to the content (default). Must be an object of class \link{unit} or a number between 0 and 1.}
 
-\item{offset}{Amount of space to add to the distance between boxes (in the x coordinate). If positive, this distance will be larger. If negative, it will be smaller. This number has to be at least between 0 and 1 (plot limits) and the resulting x coordinate cannot exceed these plot limits. The default is NULL (no offset).}
+\item{offset}{Amount of space to add to the distance between boxes (in the x coordinate). If positive, this distance will be larger. If negative, it will be smaller. This number has to be at least between 0 and 1 (plot limits) and the resulting x coordinate cannot exceed these plot limits. The default is \code{NULL} (no offset).}
 }
 \value{
 List with the dataset grouped by the splitting variable and the flowchart parameters with the resulting split.

--- a/man/fc_stack.Rd
+++ b/man/fc_stack.Rd
@@ -9,7 +9,7 @@ fc_stack(fcs, unite = FALSE)
 \arguments{
 \item{fcs}{list with all the flowcharts that we want to merge}
 
-\item{unite}{logical value if the boxes have to be united or not. Default is FALSE.}
+\item{unite}{logical value if the boxes have to be united or not. Default is \code{FALSE}.}
 }
 \value{
 List containing a list with the datasets belonging to each flowchart and the flowchart parameters combining all the flowcharts.

--- a/man/fc_theme.Rd
+++ b/man/fc_theme.Rd
@@ -49,53 +49,53 @@ fc_theme(
 
 \item{text_pattern_exc}{Text pattern for the exclusion box.}
 
-\item{just}{Justification for the text: left, center or right.}
+\item{just}{Justification for the text: \code{"left"}, \code{"center"} or \code{"right"}.}
 
-\item{text_color}{Color of the text. See the `col` parameter for \code{\link{gpar}}.}
+\item{text_color}{Color of the text. See the \code{col} parameter for \link{gpar}.}
 
-\item{text_fs}{Font size of the text. See the `fontsize` parameter for \code{\link{gpar}}.}
+\item{text_fs}{Font size of the text. See the \code{fontsize} parameter for \link{gpar}.}
 
-\item{text_fface}{Font face of the text. See the `fontface` parameter for \code{\link{gpar}}.}
+\item{text_fface}{Font face of the text. See the \code{fontface} parameter for \link{gpar}.}
 
-\item{text_ffamily}{Changes the font family of the text. See the `fontfamily` parameter for \code{\link{gpar}}.}
+\item{text_ffamily}{Changes the font family of the text. See the \code{fontfamily} parameter for \link{gpar}.}
 
 \item{text_padding}{Changes the text padding inside the box. This number has to be greater than 0.}
 
-\item{bg_fill}{Box background color. See the `fill` parameter for \code{\link{gpar}}.}
+\item{bg_fill}{Box background color. See the \code{fill} parameter for \link{gpar}.}
 
-\item{border_color}{Box border color. See the `col` parameter for \code{\link{gpar}}.}
+\item{border_color}{Box border color. See the \code{col} parameter for \link{gpar}.}
 
-\item{width}{Width of the box. Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{width}{Width of the box. Must be an object of class \link{unit} or a number between 0 and 1.}
 
-\item{height}{Height of the box. Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{height}{Height of the box. Must be an object of class \link{unit} or a number between 0 and 1.}
 
-\item{just_exc}{Justification for the text of the exclude box: left, center or right.}
+\item{just_exc}{Justification for the text of the exclude box: \code{"left"}, \code{"center"} or \code{"right"}.}
 
-\item{text_color_exc}{Color of the text of the exclude box. See `text_color`.}
+\item{text_color_exc}{Color of the text of the exclude box. See \code{text_color}.}
 
-\item{text_fs_exc}{Font size of the text of the exclude box. See `text_fs`.}
+\item{text_fs_exc}{Font size of the text of the exclude box. See \code{text_fs}.}
 
-\item{text_fface_exc}{Font face of the text of the exclude box. See the `fontface` parameter for \code{\link{gpar}}. See `text_fface`.}
+\item{text_fface_exc}{Font face of the text of the exclude box. See the \code{fontface} parameter for \link{gpar}. See \code{text_fface}.}
 
-\item{text_ffamily_exc}{Changes the font family of the text of the exclude box. See the `fontfamily` parameter for \code{\link{gpar}}. See `text_ffamily`.}
+\item{text_ffamily_exc}{Changes the font family of the text of the exclude box. See the \code{fontfamily} parameter for \link{gpar}. See \code{text_ffamily}.}
 
 \item{text_padding_exc}{Changes the text padding inside the exclude box. This number has to be greater than 0.}
 
-\item{bg_fill_exc}{Exclude box background color. See `bg_fill`.}
+\item{bg_fill_exc}{Exclude box background color. See \code{bg_fill}.}
 
-\item{border_color_exc}{Box background color of the exclude box. See `border_color`.}
+\item{border_color_exc}{Box background color of the exclude box. See \code{border_color}.}
 
-\item{width_exc}{Width of the exclude box. Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{width_exc}{Width of the exclude box. Must be an object of class \link{unit} or a number between 0 and 1.}
 
-\item{height_exc}{Height of the box. Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{height_exc}{Height of the box. Must be an object of class \link{unit} or a number between 0 and 1.}
 
 \item{text_color_title}{Color of the title text.}
 
 \item{text_fs_title}{Font size of the title text.}
 
-\item{text_fface_title}{Font face of the title text. See the `fontface` parameter for \code{\link{gpar}}.}
+\item{text_fface_title}{Font face of the title text. See the \code{fontface} parameter for \link{gpar}.}
 
-\item{text_ffamily_title}{Changes the font family of the title text. See the `fontfamily` parameter for \code{\link{gpar}}.}
+\item{text_ffamily_title}{Changes the font family of the title text. See the \code{fontfamily} parameter for \link{gpar}.}
 
 \item{text_padding_title}{Changes the title text padding inside the box. This number has to be greater than 0.}
 
@@ -103,9 +103,9 @@ fc_theme(
 
 \item{border_color_title}{Title box border color.}
 
-\item{width_title}{Width of the title box. Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{width_title}{Width of the title box. Must be an object of class \link{unit} or a number between 0 and 1.}
 
-\item{height_title}{Height of the title box. Must be an object of class \code{\link{unit}} or a number between 0 and 1.}
+\item{height_title}{Height of the title box. Must be an object of class \link{unit} or a number between 0 and 1.}
 }
 \value{
 List with the dataset and the flowchart parameters with their modifications.

--- a/man/fc_view.Rd
+++ b/man/fc_view.Rd
@@ -9,13 +9,13 @@ fc_view(object, what)
 \arguments{
 \item{object}{fc object that we want to access.}
 
-\item{what}{Choose "data" to return the data associated to the flowchart stored in `$data` or "fc" to return the flowchart information stored in `$fc`.}
+\item{what}{Choose \code{"data"} to return the data associated to the flowchart stored in \verb{$data} or \code{"fc"} to return the flowchart information stored in \verb{$fc}.}
 }
 \value{
-Returns a tibble. Either `$data` or `$fc`.
+Returns a tibble. Either \verb{$data} or \verb{$fc}.
 }
 \description{
-This function allows you to return either the data stored in `$data` or the flowchart information stored in `$fc`.
+This function allows you to return either the data stored in \verb{$data} or the flowchart information stored in \verb{$fc}.
 }
 \examples{
 #Return the data associated to the flowchart

--- a/man/format_percentage.Rd
+++ b/man/format_percentage.Rd
@@ -14,6 +14,6 @@ format_percentage(value, round_digits, trim_trailing_zeros)
 \item{trim_trailing_zeros}{logical; trim trailing zeros or not in returned value.}
 }
 \description{
-rounds percentage values while allowing the option to `trim_trailing_zeros`
+rounds percentage values while allowing the option to \code{trim_trailing_zeros}
 }
 \keyword{internal}

--- a/man/quiet_prettyNum.Rd
+++ b/man/quiet_prettyNum.Rd
@@ -12,6 +12,6 @@ quiet_prettyNum(x, big.mark)
 \item{big.mark}{character. Used to specify the thousands separator for patient count values.}
 }
 \description{
-Wrapper for `prettyNum()` that suppresses the original warning message if user `big.mark` equal to the character defined in the R environment `OutDec` option.
+Wrapper for \code{prettyNum()} that suppresses the original warning message if user \code{big.mark} equal to the character defined in the R environment \code{OutDec} option.
 }
 \keyword{internal}

--- a/man/replace_num_in_expr.Rd
+++ b/man/replace_num_in_expr.Rd
@@ -7,13 +7,13 @@
 replace_num_in_expr(expr, row, big.mark)
 }
 \arguments{
-\item{expr}{expression in `fc$text`.}
+\item{expr}{expression in \code{fc$text}.}
 
-\item{row}{A row from the `fc` object containing `n`, `N`, and `perc` values.}
+\item{row}{A row from the \code{fc} object containing \code{n}, \code{N}, and \code{perc} values.}
 
 \item{big.mark}{character. Used to specify the thousands separator for patient count values.}
 }
 \description{
-Helper function for `update_numbers()`.
+Helper function for \code{update_numbers()}.
 }
 \keyword{internal}

--- a/man/safo.Rd
+++ b/man/safo.Rd
@@ -6,28 +6,28 @@
 \title{Random generated dataset from the SAFO study}
 \format{
 A data frame with 925 rows and 21 columns
- \describe{
-  \item{id:}{Identifier of each patient. This information does not match the real data.}
-  \item{inclusion_crit:}{The patient not met the inclusion criteria?}
-  \item{exclusion_crit:}{The patient met the exclusion criteria?}
-  \item{chronic_heart_failure:}{Exc1: Chronic heart failure?}
-  \item{expected_death_24h:}{Exc2: Clinical status with expected death in <24h?}
-  \item{polymicrobial_bacteremia:}{Exc3: Polymicrobial bacteremia?}
-  \item{conditions_affect_adhrence:}{Exc4: Conditions expected to affect adhrence to the protocol?}
-  \item{susp_prosthetic_valve_endocard:}{Exc5: Suspicion of prosthetic valve endocarditis?}
-  \item{severe_liver_cirrhosis:}{Exc6: Severe liver cirrhosis?}
-  \item{acute_sars_cov2:}{Exc7: Acute SARS-CoV-2 infection?}
-  \item{blactam_fosfomycin_hypersens:}{Exc8: Beta-lactam or fosfomycin hypersensitivity?}
-  \item{other_clinical_trial:}{Exc9: Participation in another clinical trial?}
-  \item{pregnancy_or_breastfeeding:}{Exc10: Pregnancy or breastfeeding?}
-  \item{previous_participation:}{Exc11: Previous participation in the SAFO trial?}
-  \item{myasthenia_gravis:}{Exc12: Myasthenia gravis?}
-  \item{decline_part:}{The patient declined to participate?}
-  \item{group:}{Randomized treatment received: cloxacilin alone / cloxacilin plus fosfomycin}
-  \item{itt:}{The patient belongs to the intention to treat (ITT) group?}
-  \item{reason_itt:}{Reason for exclusion from the ITT group.}
-  \item{pp:}{The patient belongs to the per protocol (PP) group?}
-  \item{reason_pp:}{Reason for exclusion from the PP group.}
+\describe{
+\item{id:}{Identifier of each patient. This information does not match the real data.}
+\item{inclusion_crit:}{The patient not met the inclusion criteria?}
+\item{exclusion_crit:}{The patient met the exclusion criteria?}
+\item{chronic_heart_failure:}{Exc1: Chronic heart failure?}
+\item{expected_death_24h:}{Exc2: Clinical status with expected death in <24h?}
+\item{polymicrobial_bacteremia:}{Exc3: Polymicrobial bacteremia?}
+\item{conditions_affect_adhrence:}{Exc4: Conditions expected to affect adhrence to the protocol?}
+\item{susp_prosthetic_valve_endocard:}{Exc5: Suspicion of prosthetic valve endocarditis?}
+\item{severe_liver_cirrhosis:}{Exc6: Severe liver cirrhosis?}
+\item{acute_sars_cov2:}{Exc7: Acute SARS-CoV-2 infection?}
+\item{blactam_fosfomycin_hypersens:}{Exc8: Beta-lactam or fosfomycin hypersensitivity?}
+\item{other_clinical_trial:}{Exc9: Participation in another clinical trial?}
+\item{pregnancy_or_breastfeeding:}{Exc10: Pregnancy or breastfeeding?}
+\item{previous_participation:}{Exc11: Previous participation in the SAFO trial?}
+\item{myasthenia_gravis:}{Exc12: Myasthenia gravis?}
+\item{decline_part:}{The patient declined to participate?}
+\item{group:}{Randomized treatment received: cloxacilin alone / cloxacilin plus fosfomycin}
+\item{itt:}{The patient belongs to the intention to treat (ITT) group?}
+\item{reason_itt:}{Reason for exclusion from the ITT group.}
+\item{pp:}{The patient belongs to the per protocol (PP) group?}
+\item{reason_pp:}{Reason for exclusion from the PP group.}
 }
 }
 \usage{

--- a/man/update_numbers.Rd
+++ b/man/update_numbers.Rd
@@ -9,9 +9,9 @@ update_numbers(object, big.mark = "")
 \arguments{
 \item{object}{fc object that we want to draw.}
 
-\item{big.mark}{character. Used to specify the thousands separator for patient count values. Defaults is no separator (`""`); if not empty used as mark between every 3 digits (ex: `big.mark = ","` results in `1,000` instead of `1000`).}
+\item{big.mark}{character. Used to specify the thousands separator for patient count values. Defaults is no separator (\code{""}); if not empty used as mark between every 3 digits (ex: \code{big.mark = ","} results in \verb{1,000} instead of \code{1000}).}
 }
 \description{
-Updates values of `n` or `N` referenced in the `text` column when user specifies `big.mark` argument in `fc_draw`.
+Updates values of \code{n} or \code{N} referenced in the \code{text} column when user specifies \code{big.mark} argument in \code{fc_draw}.
 }
 \keyword{internal}

--- a/man/update_y_stack_unite.Rd
+++ b/man/update_y_stack_unite.Rd
@@ -14,6 +14,6 @@ update_y_stack_unite(y, x, type)
 \item{type}{type of the boxes}
 }
 \description{
-Function to update the vertical position of the previuosly created flowcharts, to stack the two flowcharts with fc_stack(), when `unite` is TRUE.
+Function to update the vertical position of the previuosly created flowcharts, to stack the two flowcharts with fc_stack(), when \code{unite} is TRUE.
 }
 \keyword{internal}


### PR DESCRIPTION
@pasahe While I was adding documentation, I noticed a bug with how the markdown text was not getting rendered properly. I fixed this in the DESCRIPTION file and then made some edits to the roxygen headers to maintain auto-links between packages (replacing the `\link{}` calls with simple square brackets that achieve the same thing). The thing that made me notice the bug was that the bullet points were not rendering in `fc_export()` details section the way they should have been before this fix.

After that was fixed, then I committed the updates to `fc_draw()` and `fc_export()` that were the primary concern for #43.

## Example:
```
safo |>
  as_fc(label = "Patients assessed for eligibility") |>
  fc_filter(
    !is.na(group), 
    label = "Randomized", 
    show_exc = TRUE,
    perc_total = TRUE
  ) |>
  fc_draw(
    arrow_lwd = 3,
    arrow_lineend = "butt",
    arrow_linejoin = "mitre",
    arrow_color = "red"
  )
```

Result:
<img width="256" height="251" alt="image" src="https://github.com/user-attachments/assets/1db4890b-45b5-43f4-8fc1-3121666b57f7" />


Closes #43 